### PR TITLE
fix: broken scroll on storage and runtime calls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,17 +10,21 @@ import { Transactions } from "./pages/Transactions"
 
 export default function App() {
   return (
-    <div className="w-full max-w-screen-lg h-screen bg-background flex flex-col">
+    <div className="w-full h-screen bg-background flex flex-col">
       <Header />
-      <Routes>
-        <Route path="explorer/*" element={<Explorer />} />
-        <Route path="extrinsics/*" element={<Extrinsics />} />
-        <Route path="storage/*" element={<Storage />} />
-        <Route path="constants/*" element={<Constants />} />
-        <Route path="runtimeCalls/*" element={<RuntimeCalls />} />
-        <Route path="metadata/*" element={<Metadata />} />
-        <Route path="*" element={<Navigate to="/explorer" replace />} />
-      </Routes>
+      <div className="flex-1 overflow-auto relative">
+        <div className="max-w-screen-lg m-auto">
+          <Routes>
+            <Route path="explorer/*" element={<Explorer />} />
+            <Route path="extrinsics/*" element={<Extrinsics />} />
+            <Route path="storage/*" element={<Storage />} />
+            <Route path="constants/*" element={<Constants />} />
+            <Route path="runtimeCalls/*" element={<RuntimeCalls />} />
+            <Route path="metadata/*" element={<Metadata />} />
+            <Route path="*" element={<Navigate to="/explorer" replace />} />
+          </Routes>
+        </div>
+      </div>
       <Transactions />
     </div>
   )

--- a/src/pages/Constants.tsx
+++ b/src/pages/Constants.tsx
@@ -35,7 +35,7 @@ export const Constants = withSubscribe(
     const entries = useStateObservable(metadataConstants$)
 
     return (
-      <div className="p-4 pb-0 flex flex-col gap-2 items-start overflow-auto leading-relaxed">
+      <div className="p-4 pb-0 flex flex-col gap-2 items-start leading-relaxed">
         <ul>
           {entries.map(({ name, constants }) => (
             <PalletConstants key={name} name={name} entries={constants} />

--- a/src/pages/Explorer/Detail/BlockDetail.tsx
+++ b/src/pages/Explorer/Detail/BlockDetail.tsx
@@ -116,7 +116,7 @@ export const BlockDetail = () => {
     : defaultTab
 
   return (
-    <div className="overflow-auto">
+    <div>
       <div className="p-2">
         <div className="flex flex-wrap justify-between">
           <h2 className="font-bold text-xl whitespace-nowrap overflow-hidden text-ellipsis">

--- a/src/pages/Explorer/Explorer.tsx
+++ b/src/pages/Explorer/Explorer.tsx
@@ -13,7 +13,7 @@ export const Explorer = withSubscribe(
       <Route
         path="*"
         element={
-          <div className="overflow-auto p-4 pb-0">
+          <div className="p-4 pb-0">
             <Summary />
             <div className="flex gap-2 items-start flex-wrap lg:flex-nowrap">
               <BlockTable />

--- a/src/pages/Extrinsics/Extrinsics.tsx
+++ b/src/pages/Extrinsics/Extrinsics.tsx
@@ -15,6 +15,7 @@ import { map } from "rxjs"
 import { EditMode } from "./EditMode"
 import { JsonMode } from "./JsonMode"
 import { ExtrinsicModal } from "./SubmitTx/SubmitTx"
+import { twMerge } from "tailwind-merge"
 
 const extrinsicProps$ = state(
   runtimeCtx$.pipe(
@@ -51,7 +52,13 @@ export const Extrinsics = withSubscribe(
           : componentValue.value.encoded) ?? null
 
     return (
-      <div className="flex flex-col overflow-hidden gap-2 p-4 pb-0">
+      <div
+        className={twMerge(
+          "flex flex-col overflow-hidden gap-2 p-4 pb-0",
+          // Bypassing top-level scroll area, since we need a specific scroll area for the tree view
+          "absolute w-full h-full max-w-screen-lg",
+        )}
+      >
         <BinaryDisplay
           {...extrinsicProps}
           value={componentValue}

--- a/src/pages/Header.tsx
+++ b/src/pages/Header.tsx
@@ -4,33 +4,35 @@ import { FC, PropsWithChildren } from "react"
 import { twMerge } from "tailwind-merge"
 
 export const Header = () => (
-  <div className="flex p-4 pb-2 items-center flex-shrink-0 gap-2 border-b">
-    <div className="flex flex-1 items-center flex-row gap-2 relative">
-      <img
-        className="w-14 min-w-14 hidden dark:inline-block"
-        src="/papi_logo-dark.svg"
-        alt="papi-logo"
-      />
-      <img
-        className="w-14 min-w-14 dark:hidden"
-        src="/papi_logo-light.svg"
-        alt="papi-logo"
-      />
-      <h1 className="hidden lg:block poppins-regular text-lg">
-        papi <span className="poppins-extralight">console</span>
-      </h1>
-      <div className="absolute -bottom-1 left-0 lg:bottom-0 lg:right-1 text-right text-sm">
-        (beta)
+  <div className="flex-shrink-0 border-b">
+    <div className="flex p-4 pb-2 items-center gap-2 max-w-screen-lg m-auto">
+      <div className="flex flex-1 items-center flex-row gap-2 relative">
+        <img
+          className="w-14 min-w-14 hidden dark:inline-block"
+          src="/papi_logo-dark.svg"
+          alt="papi-logo"
+        />
+        <img
+          className="w-14 min-w-14 dark:hidden"
+          src="/papi_logo-light.svg"
+          alt="papi-logo"
+        />
+        <h1 className="hidden lg:block poppins-regular text-lg">
+          papi <span className="poppins-extralight">console</span>
+        </h1>
+        <div className="absolute -bottom-1 left-0 lg:bottom-0 lg:right-1 text-right text-sm">
+          (beta)
+        </div>
       </div>
-    </div>
-    <NetworkSwitcher />
-    <div className="flex flex-row items-center justify-end px-1 py-1 text-nowrap">
-      <NavLink to="/explorer">Explorer</NavLink>
-      <NavLink to="/storage">Storage</NavLink>
-      <NavLink to="/extrinsics">Extrinsics</NavLink>
-      <NavLink to="/constants">Constants</NavLink>
-      <NavLink to="/runtimeCalls">Runtime Calls</NavLink>
-      <NavLink to="/metadata">Metadata</NavLink>
+      <NetworkSwitcher />
+      <div className="flex flex-row items-center justify-end px-1 py-1 text-nowrap">
+        <NavLink to="/explorer">Explorer</NavLink>
+        <NavLink to="/storage">Storage</NavLink>
+        <NavLink to="/extrinsics">Extrinsics</NavLink>
+        <NavLink to="/constants">Constants</NavLink>
+        <NavLink to="/runtimeCalls">Runtime Calls</NavLink>
+        <NavLink to="/metadata">Metadata</NavLink>
+      </div>
     </div>
   </div>
 )


### PR DESCRIPTION
Closes #4 

I've moved the scroll area to the top layout, so the header is always fixed at the top and the content is w/e length with a scroll. This also moves the scroll bar from the inner content to the outer edge, which I think it's better.

I have also redesigned the header so that the border extends through all the screen, but the content is still centred on big displays. I think it gives it more space visually.

![image](https://github.com/user-attachments/assets/82e847cb-01fd-4c71-9ffe-5b68a7058527)
