### PR TITLE
feat: limit amount of extrinsics per block shown in event table

### DIFF
--- a/src/pages/Explorer/BlockTable.tsx
+++ b/src/pages/Explorer/BlockTable.tsx
@@ -8,6 +8,7 @@ import { twMerge } from "tailwind-merge"
 import { BlockInfo, blocksByHeight$, finalized$ } from "./block.state"
 import { BlockPopover } from "./BlockPopover"
 import * as Finalizing from "./FinalizingTable"
+import { Link } from "react-router-dom"
 
 const best$ = chainHead$.pipeState(switchMap((chainHead) => chainHead.best$))
 
@@ -124,7 +125,9 @@ export const BlockTable = () => {
                     "border-b-card-foreground/50",
                 )}
               >
-                {row.block.number.toLocaleString()}
+                <Link to={`/explorer/${row.block.hash}`}>
+                  {row.block.number.toLocaleString()}
+                </Link>
               </td>
             ) : null}
             <td className="p-0">

--- a/src/pages/Explorer/Events.tsx
+++ b/src/pages/Explorer/Events.tsx
@@ -31,19 +31,43 @@ export const Events = () => {
           const key = eventKey(evt)
           const span = numberSpan(idx)
 
+          if (!("extrinsicNumber" in evt)) {
+            return (
+              <Finalizing.Row
+                key={key}
+                number={events.length - idx}
+                finalized={events.length - finalizedIdx}
+                idx={idx}
+                firstInGroup
+              >
+                <td className="p-2 whitespace-nowrap">
+                  {evt.number.toLocaleString()}
+                </td>
+                <td
+                  className="p-1 w-full"
+                  colSpan={2}
+                >{`… ${evt.length} more extrinsics with events`}</td>
+              </Finalizing.Row>
+            )
+          }
+
+          const isFirstInGroup = eventKey(events[idx - 1]) !== key
+          const isLastInGroup = eventKey(events[idx + 1]) !== key
+          const isInGroup = !isFirstInGroup || !isLastInGroup
+
           return (
             <Finalizing.Row
-              key={`${evt.hash}-${evt.extrinsicNumber}-${evt.index}`}
+              key={`${key}-${evt.index}`}
               number={events.length - idx}
               finalized={events.length - finalizedIdx}
               idx={idx}
-              firstInGroup
+              firstInGroup={isFirstInGroup}
             >
-              {eventKey(events[idx - 1]) !== key && (
+              {isFirstInGroup && (
                 <td
                   className={twMerge(
                     "p-2 whitespace-nowrap",
-                    span > 1 &&
+                    isInGroup &&
                       twMerge(
                         idx > 0 ? "border-y" : "border-b",
                         "border-card-foreground/25",
@@ -57,7 +81,20 @@ export const Events = () => {
                   {key}
                 </td>
               )}
-              <td className="p-1 w-full">
+              <td
+                className={twMerge(
+                  "p-1 w-full",
+                  isInGroup &&
+                    twMerge(
+                      isFirstInGroup && idx > 0 && "border-t",
+                      isLastInGroup && "border-b",
+                      "border-card-foreground/25",
+                      idx === finalizedIdx && "border-t-card-foreground/50",
+                      idx === finalizedIdx - span &&
+                        "border-b-card-foreground/50",
+                    ),
+                )}
+              >
                 {"event" in evt ? (
                   <Popover content={<EventPopover event={evt} />}>
                     <button className="w-full p-1 text-left text-card-foreground/80 hover:text-card-foreground/100">{`${evt.event.type}.${evt.event.value.type}`}</button>

--- a/src/pages/Explorer/Events.tsx
+++ b/src/pages/Explorer/Events.tsx
@@ -5,6 +5,7 @@ import { finalized$ } from "./block.state"
 import { EventPopover } from "./EventPopover"
 import { eventKey, recentEvents$ } from "./events.state"
 import * as Finalizing from "./FinalizingTable"
+import { Link } from "react-router-dom"
 
 export const Events = () => {
   const events = useStateObservable(recentEvents$)
@@ -41,7 +42,9 @@ export const Events = () => {
                 firstInGroup
               >
                 <td className="p-2 whitespace-nowrap">
-                  {evt.number.toLocaleString()}
+                  <Link to={`/explorer/${evt.hash}`}>
+                    {evt.number.toLocaleString()}
+                  </Link>
                 </td>
                 <td
                   className="p-1 w-full"
@@ -78,7 +81,9 @@ export const Events = () => {
                   )}
                   rowSpan={span}
                 >
-                  {key}
+                  <Link to={`/explorer/${evt.hash}#tx=${evt.index}`}>
+                    {key}
+                  </Link>
                 </td>
               )}
               <td


### PR DESCRIPTION
This adds a limit on how many extrinsics are shown in the "Recent events" table, since in the last spamming test in kusama made the table with too many rows.

<img width="490" alt="Screenshot 2024-12-04 at 11 18 13" src="https://github.com/user-attachments/assets/3e3857bf-d749-4f8c-8692-f9292ff216b9">

Also "feat: add link on block/extrinsic number to block detail"
