### PR TITLE
fix custom network on URI

### DIFF
--- a/src/pages/Network/Network.tsx
+++ b/src/pages/Network/Network.tsx
@@ -30,6 +30,7 @@ import {
   SelectedChain,
   selectedChain$,
 } from "@/state/chains/chain.state"
+import { addCustomNetwork, getCustomNetwork } from "@/state/chains/networks"
 import { useStateObservable } from "@react-rxjs/core"
 import { useCommandState } from "cmdk"
 import { Check, ChevronDown } from "lucide-react"
@@ -114,6 +115,7 @@ export function NetworkSwitcher() {
         </Button>
       </DialogTrigger>
       <NetworkSwitchDialogContent
+        key={selectedChain.endpoint}
         selectedChain={selectedChain}
         onClose={() => setOpen(false)}
       />
@@ -148,10 +150,16 @@ const NetworkSwitchDialogContent: FC<{
   }
 
   const handleConfirm = () => {
-    onChangeChain({
-      network: selectedNetwork,
-      endpoint: selectedRpc,
-    })
+    if (selectedNetwork.id === "custom-network") {
+      addCustomNetwork(selectedRpc)
+      onChangeChain({ network: getCustomNetwork(), endpoint: selectedRpc })
+      setEnteredText("")
+    } else {
+      onChangeChain({
+        network: selectedNetwork,
+        endpoint: selectedRpc,
+      })
+    }
     onClose()
   }
 

--- a/src/pages/Network/Network.tsx
+++ b/src/pages/Network/Network.tsx
@@ -24,6 +24,7 @@ import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import {
+  isValidUri,
   Network,
   networkCategories,
   onChangeChain,
@@ -35,15 +36,6 @@ import { useStateObservable } from "@react-rxjs/core"
 import { useCommandState } from "cmdk"
 import { Check, ChevronDown } from "lucide-react"
 import { FC, useEffect, useRef, useState } from "react"
-
-const isValidUri = (input: string): boolean => {
-  try {
-    new URL(input)
-  } catch {
-    return false
-  }
-  return true
-}
 
 const EmptyOption: React.FC<{
   enteredText: string

--- a/src/state/chains/chain.state.ts
+++ b/src/state/chains/chain.state.ts
@@ -75,12 +75,26 @@ const allNetworks = networkCategories.map((x) => x.networks).flat()
 const findNetwork = (networkId: string): Network | undefined =>
   allNetworks.find((x) => x.id == networkId)
 
+export const isValidUri = (input: string): boolean => {
+  try {
+    new URL(input)
+  } catch {
+    return false
+  }
+  return true
+}
+
+const defaultSelectedChain: SelectedChain = {
+  network: defaultNetwork,
+  endpoint: "light-client",
+}
 const getDefaultChain = (): SelectedChain => {
   const hashParams = getHashParams()
   if (hashParams.has("networkId") && hashParams.has("endpoint")) {
     const networkId = hashParams.get("networkId")!
     const endpoint = hashParams.get("endpoint")!
     if (networkId === "custom") {
+      if (!isValidUri(endpoint)) return defaultSelectedChain
       addCustomNetwork(endpoint)
       return {
         network: getCustomNetwork(),
@@ -88,7 +102,7 @@ const getDefaultChain = (): SelectedChain => {
       }
     }
     const network = findNetwork(networkId)
-    if (network) return { network, endpoint }
+    if (network) return defaultSelectedChain
   }
 
   return {

--- a/src/state/chains/networks/index.ts
+++ b/src/state/chains/networks/index.ts
@@ -38,13 +38,13 @@ const networks = {
   Kusama,
   Paseo,
   Westend,
-  Development: [
+  Custom: [
     {
-      id: "localhost",
-      display: "Localhost",
+      id: "custom",
+      display: "Custom",
       lightclient: false,
       endpoints: {
-        "Local (ws://127.0.0.1:9944)": "ws://127.0.0.1:9944",
+        "ws://127.0.0.1:9944": "ws://127.0.0.1:9944",
       },
     } as Network,
   ],
@@ -53,5 +53,10 @@ const networks = {
 export const networkCategories: NetworkCategory[] = Object.entries(
   networks,
 ).map(([name, networks]) => ({ name, networks }))
+
+export const getCustomNetwork = () => networks.Custom[0]
+export const addCustomNetwork = (uri: string) => {
+  getCustomNetwork().endpoints[uri] = uri
+}
 
 export const defaultNetwork = Polkadot[0]


### PR DESCRIPTION
Closes #24 

The only thing to keep in mind is that now the URIs for custom networks look like this:
https://dev.papi.how/explorer#networkId=custom&endpoint=wss://rpc1.paseo.popnetwork.xyz