### PR TITLE
feat: add search by path to metadata lookup

### DIFF
--- a/src/pages/Metadata/Lookup.tsx
+++ b/src/pages/Metadata/Lookup.tsx
@@ -1,32 +1,82 @@
 import { ExpandBtn } from "@/components/Expand"
 import { Link } from "@/hashParams"
 import { V14Lookup } from "@polkadot-api/substrate-bindings"
-import { Edit } from "lucide-react"
+import { Edit, Search } from "lucide-react"
 import {
   createContext,
   FC,
   PropsWithChildren,
   useContext,
+  useMemo,
   useState,
 } from "react"
 import { twMerge } from "tailwind-merge"
 
 export const Lookup: FC = () => {
+  const lookup = useContext(LookupContext)
   const [id, setId] = useState(0)
+  const [search, setSearch] = useState("")
+
+  const matchingResults = useMemo(() => {
+    if (!search.trim()) return null
+
+    const tokens = search
+      .toLocaleLowerCase()
+      .split(".")
+      .map((v) => v.trim())
+      .filter((v) => v !== "")
+
+    return lookup.filter((node) =>
+      tokens.every((token) =>
+        node.path.some((p) => p.toLocaleLowerCase().startsWith(token)),
+      ),
+    )
+  }, [search, lookup])
 
   return (
     <div className="border rounded p-2 flex flex-col gap-2">
-      <label>
-        Id:{" "}
-        <input
-          className="text-sm border rounded p-2 border-polkadot-200 leading-tight text-white"
-          value={id}
-          onChange={(evt) => setId(evt.target.valueAsNumber)}
-          type="number"
-        />
-      </label>
-      <div className="border-t">
-        <LookupNode id={id} />
+      <div className="flex justify-between">
+        <label>
+          Id:{" "}
+          <input
+            className="text-sm border rounded p-2 border-polkadot-200 leading-tight text-white"
+            value={id}
+            onChange={(evt) => {
+              setSearch("")
+              setId(evt.target.valueAsNumber)
+            }}
+            type="number"
+          />
+        </label>
+        <div className="relative">
+          <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
+          <input
+            className="pl-8 px-4 py-2 border border-border leading-tight text-foreground"
+            value={search}
+            placeholder="Search by path…"
+            onChange={(evt) => setSearch(evt.target.value)}
+          />
+        </div>
+      </div>
+      <div>
+        {matchingResults ? (
+          matchingResults.length ? (
+            <div className="space-y-4">
+              {matchingResults.slice(0, 20).map(({ id }) => (
+                <div className="bg-card border rounded p-2">
+                  <p>id: {id}</p>
+                  <LookupNode key={id} id={id} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <span>No results found</span>
+          )
+        ) : (
+          <div className="bg-card border rounded p-2">
+            <LookupNode id={id} />
+          </div>
+        )}
       </div>
     </div>
   )

--- a/src/pages/Metadata/Lookup.tsx
+++ b/src/pages/Metadata/Lookup.tsx
@@ -51,7 +51,7 @@ export const Lookup: FC = () => {
         <div className="relative">
           <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-500" />
           <input
-            className="pl-8 px-4 py-2 border border-border leading-tight text-foreground"
+            className="pl-8 px-4 py-2 border border-border rounded leading-tight text-foreground"
             value={search}
             placeholder="Search by path…"
             onChange={(evt) => setSearch(evt.target.value)}

--- a/src/pages/Metadata/Metadata.tsx
+++ b/src/pages/Metadata/Metadata.tsx
@@ -1,13 +1,13 @@
-import { lookup$, metadata$ } from "@/state/chains/chain.state"
 import { LookupTypeEdit } from "@/codec-components/LookupTypeEdit"
 import { ButtonGroup } from "@/components/ButtonGroup"
 import { JsonDisplay } from "@/components/JsonDisplay"
 import { LoadingMetadata } from "@/components/Loading"
 import { withSubscribe } from "@/components/withSuspense"
+import { lookup$, metadata$ } from "@/state/chains/chain.state"
 import { getTypeComplexity } from "@/utils/shape"
 import { useStateObservable } from "@react-rxjs/core"
 import { useState } from "react"
-import { Route, Routes, useParams } from "react-router-dom"
+import { Route, Routes, useNavigate, useParams } from "react-router-dom"
 import { Extrinsic } from "./Extrinsic"
 import { Lookup, LookupContext } from "./Lookup"
 import { Pallets } from "./Pallets"
@@ -17,8 +17,8 @@ import { Custom, OuterEnums } from "./V15Fields"
 export const Metadata = withSubscribe(
   () => (
     <Routes>
-      <Route path="editor/:id" element={<Editor />} />
-      <Route path="*" element={<MetadataExplorer />} />
+      <Route path="lookup/editor/:id" element={<Editor />} />
+      <Route path=":mode?" element={<MetadataExplorer />} />
     </Routes>
   ),
   {
@@ -27,7 +27,13 @@ export const Metadata = withSubscribe(
 )
 
 const MetadataExplorer = () => {
-  const [mode, setMode] = useState<string>("pallets")
+  const params = useParams()
+  const navigate = useNavigate()
+  const mode = params.mode || "pallets"
+  const setMode = (mode: string) =>
+    navigate("../" + mode, {
+      replace: true,
+    })
   const metadata = useStateObservable(metadata$)
 
   const tabs = [
@@ -101,11 +107,13 @@ const Editor = () => {
   const complexity = getTypeComplexity(shape)
 
   return (
-    <LookupTypeEdit
-      type={Number(id)}
-      value={value}
-      onValueChange={setValue}
-      tree={complexity === "tree"}
-    />
+    <div className="p-4">
+      <LookupTypeEdit
+        type={Number(id)}
+        value={value}
+        onValueChange={setValue}
+        tree={complexity === "tree"}
+      />
+    </div>
   )
 }


### PR DESCRIPTION
Closes #17 

We needed a way of encoding/decoding arbitrary types from the metadata.

The lookup was already available in the metadata page, along with a link to the codec view, but it was hard to look for one type in specific.

This PR adds in a search field that will filter by path, so now it's a easier to find them.

I also added some basic routing to the metadata page, as it wasn't done yet.

https://github.com/user-attachments/assets/9acc54f4-6109-461b-9b70-18206fe5ffb5

