### PR TITLE
Add westend penpal to list of networks

### DIFF
--- a/src/state/chains/networks/westend.json
+++ b/src/state/chains/networks/westend.json
@@ -119,5 +119,22 @@
       "decimals": 12
     },
     "hasChainSpecs": false
+  },
+  {
+    "id": "westend_penpal",
+    "display": "Penpal",
+    "rpcs": {
+      "Parity": "wss://westend-penpal-rpc.polkadot.io"
+    },
+    "relayChainInfo": {
+      "id": "westend",
+      "isSystem": false,
+      "parachain": 2042
+    },
+    "nativeToken": {
+      "symbol": "PEN",
+      "decimals": 12
+    },
+    "hasChainSpecs": false
   }
 ]


### PR DESCRIPTION
We recently launched a new test network in Westend: Penpal. It's a non-system chain so we can test reserve asset transfers among other things. I added it to the list of networks for ease of use.

I'll also add the chainspec to polkadot-api.
