### PR TITLE
fix: don't crash if extrinsics is not loaded yet

### DIFF
--- a/src/pages/Explorer/Detail/BlockBody.tsx
+++ b/src/pages/Explorer/Detail/BlockBody.tsx
@@ -65,7 +65,7 @@ export const BlockBody: FC<{
   const getDefaultTab = (): Tab => {
     if (defaultEventOpen) {
       return defaultEventOpen.phase.type === "ApplyExtrinsic"
-        ? extrinsics[defaultEventOpen.phase.value].signed
+        ? extrinsics[defaultEventOpen.phase.value]?.signed
           ? "signed"
           : "unsigned"
         : "events"


### PR DESCRIPTION
I made a small mistake while adding support to init and finalization events in #42.
This fixes it 🙈 