### PR TITLE
Various fixes and smol improvements

### DIFF
--- a/src/codec-components/EditCodec/Tree/CEnum.tsx
+++ b/src/codec-components/EditCodec/Tree/CEnum.tsx
@@ -43,23 +43,26 @@ export const CEnum: EditEnum = ({
   const innerPath = [...path, value.type]
   const pathStr = path.join(".")
   if (titleContainer) {
-    return (
+    return titleElement ? (
       <>
-        {titleElement ? (
-          <Portal node={titleElement}>
-            <span
-              onClick={() => scrollToMarker(innerPath)}
-              onMouseEnter={() =>
-                setHovered(pathId, { id: pathStr, hover: true })
-              }
-              onMouseLeave={() =>
-                setHovered(pathId, { id: pathStr, hover: false })
-              }
-            >
-              / {value.type}
-            </span>
-          </Portal>
-        ) : null}
+        <Portal node={titleElement}>
+          <span
+            onClick={() => scrollToMarker(innerPath)}
+            onMouseEnter={() =>
+              setHovered(pathId, { id: pathStr, hover: true })
+            }
+            onMouseLeave={() =>
+              setHovered(pathId, { id: pathStr, hover: false })
+            }
+          >
+            / {value.type}
+          </span>
+        </Portal>
+        {/* It's important not to show the inner elements until this one isn't
+        ready, because elements must be appended in order.
+        Bug was: Utility.Batch(System.remark(whatever)) then refresh page. The
+        enum for the inner call would show up reversed (/remark/System)
+        Be careful, in strict mode (dev) this bug doesn't show up. */}
         <ChildrenProviders
           titleElement={titleContainer ?? newElement}
           onValueChange={() => {}}
@@ -67,7 +70,7 @@ export const CEnum: EditEnum = ({
           {inner}
         </ChildrenProviders>
       </>
-    )
+    ) : null
   }
 
   const innerShape = shape.value[value.type]

--- a/src/codec-components/LookupTypeEdit/LookupTypeEdit.tsx
+++ b/src/codec-components/LookupTypeEdit/LookupTypeEdit.tsx
@@ -6,8 +6,9 @@ import {
 } from "@polkadot-api/react-builder"
 import { state, useStateObservable } from "@react-rxjs/core"
 import { Codec } from "polkadot-api"
-import { ComponentProps, FC, useEffect, useRef, useState } from "react"
+import { ComponentProps, FC, useEffect, useState } from "react"
 import { map } from "rxjs"
+import { twMerge } from "tailwind-merge"
 import {
   Marker,
   MarkersContextProvider,
@@ -19,7 +20,6 @@ import { EditCodec } from "../EditCodec"
 import { TreeCodec } from "../EditCodec/Tree"
 import { BinaryDisplay } from "./BinaryDisplay"
 import { FocusPath } from "./FocusPath"
-import { twMerge } from "tailwind-merge"
 
 const editTypeMetadataProps$ = state(
   runtimeCtx$.pipe(
@@ -38,14 +38,14 @@ export const LookupTypeEdit: FC<{
   tree?: boolean
   className?: string
 }> = ({ type, value, onValueChange, tree = true, className }) => {
-  const treeRef = useRef<HTMLDivElement | null>(null)
-  const listRef = useRef<HTMLDivElement | null>(null)
+  const [treeRef, setTreeRef] = useState<HTMLDivElement | null>(null)
+  const [listRef, setListRef] = useState<HTMLDivElement | null>(null)
   const [focusingSubtree, setFocusingSubtree] = useState<string[] | null>(null)
 
   useEffect(() => {
-    if (!listRef.current || !treeRef.current) return
-    return synchronizeScroll(listRef.current, treeRef.current)
-  }, [])
+    if (!listRef || !treeRef) return
+    return synchronizeScroll(listRef, treeRef)
+  }, [listRef, treeRef])
 
   const codecProps = useCodecProps(type, value, onValueChange)
 
@@ -72,12 +72,12 @@ export const LookupTypeEdit: FC<{
       >
         <MarkersContextProvider>
           <div
-            ref={listRef}
+            ref={setListRef}
             className="flex flex-row overflow-auto w-full gap-2"
           >
             {tree && (
               <div
-                ref={treeRef}
+                ref={setTreeRef}
                 className="w-96 sticky top-0 pl-2 pb-16 leading-loose overflow-hidden max-sm:hidden"
               >
                 <div className="relative">

--- a/src/codec-components/ViewCodec/CBytes.tsx
+++ b/src/codec-components/ViewCodec/CBytes.tsx
@@ -1,13 +1,27 @@
-import { bytesToString } from "@/components/BinaryInput"
+import { getBytesFormat } from "@/components/BinaryInput"
 import { ViewBytes } from "@polkadot-api/react-builder"
 import { useReportBinary } from "./CopyBinary"
+import { SwitchBinary } from "@/components/Icons"
+import { useState } from "react"
 
 export const CBytes: ViewBytes = ({ value, encodedValue }) => {
+  const [forceBinary, setForceBinary] = useState(false)
+
   useReportBinary(encodedValue)
+  const format = getBytesFormat(value)
 
   return (
     <div className="min-w-80 border-none p-0 outline-hidden bg-transparent flex-1 overflow-hidden text-ellipsis">
-      {bytesToString(value)}
+      {format.type === "text" ? (
+        <button
+          className="align-middle mr-2 cursor-pointer text-foreground/90"
+          type="button"
+          onClick={() => setForceBinary((b) => !b)}
+        >
+          <SwitchBinary size={24} />
+        </button>
+      ) : null}
+      {forceBinary ? value.asHex() : format.value}
     </div>
   )
 }

--- a/src/components/BinaryInput.tsx
+++ b/src/components/BinaryInput.tsx
@@ -71,7 +71,7 @@ export const BinaryInput: React.FC<{
       {(input) => (
         <div
           className={twMerge(
-            "px-4 py-2 border border-border rounded leading-tight focus-within:outline focus-within:outline-1 flex items-center gap-2 bg-input",
+            "px-4 py-2 border border-border rounded leading-tight focus-within:outline flex items-center gap-2 bg-input",
             warn ? "border-orange-400" : null,
             uploadError ? "border-red-600" : null,
           )}
@@ -159,15 +159,22 @@ const serializeValue = (value: Binary): string | Binary => {
 }
 
 const textDecoder = new TextDecoder("utf-8", { fatal: true })
-export const bytesToString = (value: Binary) => {
+export const getBytesFormat = (value: Binary) => {
   try {
     const bytes = value.asBytes()
     if (bytes.slice(0, 5).every((b) => b < 32)) throw null
-    return textDecoder.decode(bytes)
+    return {
+      type: "text",
+      value: textDecoder.decode(bytes),
+    }
   } catch (_) {
-    return value.asHex()
+    return {
+      type: "hex",
+      value: value.asHex(),
+    }
   }
 }
+export const bytesToString = (value: Binary) => getBytesFormat(value).value
 
 export const checkEqualInputBinary = (
   input: string | Binary,

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -20,6 +20,7 @@ import chopsticksLogoDark from "./icons/chopsticks_dark.svg"
 import chopsticksLogoLight from "./icons/chopsticks_light.svg"
 import enumSvg from "./icons/enum.svg"
 import focusSvg from "./icons/focus.svg"
+import switchBinarySvg from "./icons/switch_binary.svg"
 import walletConnectSvg from "./icons/walletConnect.svg"
 
 type CustomIconProps = Omit<Props, "ref" | "src"> & { size?: number }
@@ -62,6 +63,7 @@ export const Focus = customIcon(focusSvg)
 export const Enum = customIcon(enumSvg)
 export const BinaryEdit = customIcon(binarySvg)
 export const WalletConnect = customIcon(walletConnectSvg)
+export const SwitchBinary = customIcon(switchBinarySvg)
 export const Chopsticks = themeIcon(chopsticksLogoLight, chopsticksLogoDark)
 
 export const Spinner = (props: LucideProps) => (

--- a/src/components/icons/switch_binary.svg
+++ b/src/components/icons/switch_binary.svg
@@ -1,0 +1,24 @@
+<svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24" height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="1"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+>
+    <text x="2" y="19" font-size="8" font-family="monospace" fill="currentColor" stroke="none">
+    0x
+    </text>
+
+    <text x="14" y="8" font-size="8" font-family="sans-serif" fill="currentColor" stroke="none">
+    Aa
+    </text>
+
+    <path d="M4 11 L4 5 L12 5" />
+    <path d="M10 3 L12 5 L10 7" />
+
+    <path d="M22 10 L22 16 L14 16" />
+    <path d="M16 14 L14 16 L16 18" />
+</svg>

--- a/src/pages/Storage/StorageSubscriptions.tsx
+++ b/src/pages/Storage/StorageSubscriptions.tsx
@@ -158,7 +158,11 @@ const DecodedResultDisplay: FC<{
 
   return (
     <div className="max-h-[60svh] overflow-auto">
-      {values.map(({ keyArgs, value }, i) => renderItem(keyArgs, value, i))}
+      {values.length ? (
+        values.map(({ keyArgs, value }, i) => renderItem(keyArgs, value, i))
+      ) : (
+        <span className="text-foreground/60">Empty</span>
+      )}
     </div>
   )
 }

--- a/src/state/chains/chain.state.ts
+++ b/src/state/chains/chain.state.ts
@@ -12,6 +12,7 @@ import { sinkSuspense, state, SUSPENSE } from "@react-rxjs/core"
 import { createSignal } from "@react-rxjs/utils"
 import { createClient } from "polkadot-api"
 import {
+  catchError,
   concat,
   EMPTY,
   filter,
@@ -224,6 +225,15 @@ export const chainClient$ = state(
   ),
 )
 export const client$ = state(chainClient$.pipe(map(({ client }) => client)))
+
+export const canProduceBlocks$ = state(
+  client$.pipe(
+    switchMap((client) => client._request("rpc_methods", [])),
+    map((response) => response.methods.includes("dev_newBlock")),
+    catchError(() => [false]),
+  ),
+  false,
+)
 
 export const unsafeApi$ = chainClient$.pipeState(
   map(({ client }) => client.getUnsafeApi()),


### PR DESCRIPTION
- Fix: the tree view doesn't scroll in runtime api parameters

https://github.com/user-attachments/assets/6ada4280-482c-44ee-ab77-fa5611ed892f

- Feat: add toggle on binary view to switch between text and hex

https://github.com/user-attachments/assets/f9dfe5be-a5f0-431a-87c7-5537b01e7268

- Fix: getEntries shows nothing when it's empty. Now it will show "Empty" instead.

![Screenshot 2025-06-19 at 10 03 47](https://github.com/user-attachments/assets/2a632acc-2bd9-4410-a02a-17a35dee9108)

- Feat: show "Jump to block" if chain supports `dev_newBlock`. Idea is to have this feature when connected to an external chopsticks instance. A pending/known issue with this is that when jumping many blocks, the block height will become out-of-sync with the console.

- Fix: Enums show up as reversed in the tree view when loading from a pre-filled URL. See the `/ remark / System` below

![Screenshot 2025-06-19 at 10 04 33](https://github.com/user-attachments/assets/f823ade9-b539-4215-99d8-28ed5709f379)
