### PR TITLE
sequences: add item duplication

### DIFF
--- a/src/codec-components/EditCodec/CSequence.tsx
+++ b/src/codec-components/EditCodec/CSequence.tsx
@@ -1,5 +1,5 @@
 import { EditSequence, NOTIN } from "@polkadot-api/react-builder"
-import { CirclePlus } from "lucide-react"
+import { CirclePlus, Copy } from "lucide-react"
 import { twMerge as clsx } from "tailwind-merge"
 import { ListItem } from "../common/ListItem"
 import { useSubtreeFocus } from "../common/SubtreeFocus"
@@ -18,7 +18,6 @@ export const CSequence: EditSequence = ({
 
   const addItem = () => {
     const curr = value !== NOTIN ? value.slice() : []
-
     curr.push(NOTIN)
     onValueChanged([...curr])
   }
@@ -29,6 +28,13 @@ export const CSequence: EditSequence = ({
     onValueChanged([...curr])
   }
 
+  const duplicateItem = (idx: number) => {
+    if (value === NOTIN) return
+    const curr = value.slice()
+    curr.splice(idx + 1, 0, curr[idx])
+    onValueChanged([...curr])
+  }
+
   return (
     <div>
       <ul>
@@ -36,9 +42,8 @@ export const CSequence: EditSequence = ({
           <ListItem
             key={idx}
             idx={idx}
-            onDelete={() => {
-              removeItem(idx)
-            }}
+            onDelete={() => removeItem(idx)}
+            onDuplicate={value !== NOTIN ? () => duplicateItem(idx) : undefined}
             path={[...path, String(idx)]}
           >
             {item}

--- a/src/codec-components/common/ListItem.tsx
+++ b/src/codec-components/common/ListItem.tsx
@@ -1,6 +1,6 @@
 import { ExpandBtn } from "@/components/Expand"
 import { useStateObservable } from "@react-rxjs/core"
-import { Dot, Trash2 } from "lucide-react"
+import { Dot, Trash2, Copy } from "lucide-react"
 import { ReactNode, useContext } from "react"
 import { twMerge as clsx, twMerge } from "tailwind-merge"
 import { Marker } from "./Markers"
@@ -17,9 +17,10 @@ export const ListItem: React.FC<{
   children: React.ReactNode
   path: string[]
   onDelete?: () => void
+  onDuplicate?: () => void
   actions?: ReactNode
   inline?: boolean
-}> = ({ idx, onDelete, children, path, actions, inline }) => {
+}> = ({ idx, onDelete, onDuplicate, children, path, actions, inline }) => {
   const pathsRootId = useContext(PathsRoot)
   const pathStr = path.join(".")
   const isActive = useStateObservable(isActive$(pathStr))
@@ -33,37 +34,55 @@ export const ListItem: React.FC<{
         Item {idx + 1}.
       </span>
       <div className="flex-1">{children}</div>
-      {onDelete ? (
+      {onDuplicate && (
         <button
           className="cursor-pointer text-foreground/80 ml-2 hover:text-primary"
-          onClick={() => onDelete()}
+          onClick={onDuplicate}
+          title="Duplicate item"
+        >
+          <Copy size={16} />
+        </button>
+      )}
+      {onDelete && (
+        <button
+          className="cursor-pointer text-foreground/80 ml-2 hover:text-primary"
+          onClick={onDelete}
         >
           <Trash2 size={16} />
         </button>
-      ) : null}
+      )}
       {actions}
     </div>
   ) : (
-    <div className="flex items-center">
-      <Marker id={path} />
-      <span
-        className="cursor-pointer flex items-center py-1 gap-1"
-        onClick={() => toggleCollapsed(pathsRootId, pathStr)}
-      >
-        <ExpandBtn expanded={!isCollapsed} />
-        Item {idx + 1}.
-      </span>
-      {onDelete ? (
-        <button
-          className="cursor-pointer text-foreground/80 ml-2 hover:text-primary"
-          onClick={() => onDelete()}
+      <div className="flex items-center">
+        <Marker id={path} />
+        <span
+          className="cursor-pointer flex items-center py-1 gap-1"
+          onClick={() => toggleCollapsed(pathsRootId, pathStr)}
         >
-          <Trash2 size={16} />
-        </button>
-      ) : null}
-      {actions}
-    </div>
-  )
+          <ExpandBtn expanded={!isCollapsed} />
+          Item {idx + 1}.
+        </span>
+        {onDuplicate && (
+          <button
+            className="cursor-pointer text-foreground/80 ml-2 hover:text-primary"
+            onClick={onDuplicate}
+            title="Duplicate item"
+          >
+            <Copy size={16} />
+          </button>
+        )}
+        {onDelete && (
+          <button
+            className="cursor-pointer text-foreground/80 ml-2 hover:text-primary"
+            onClick={onDelete}
+          >
+            <Trash2 size={16} />
+          </button>
+        )}
+        {actions}
+      </div>
+    )
 
   return (
     <li


### PR DESCRIPTION
adds a copy button to duplicate array items because manually recreating complex nested structures is tedious af. the button appears next to delete, duplicates to position n+1, and works for all item types (structs, enums, primitives).

touches CSequence and ListItem only. no breaking changes.