### PR TITLE
feat: set storage of external chopsticks instances

### DIFF
--- a/src/chopsticks/chopsticks.ts
+++ b/src/chopsticks/chopsticks.ts
@@ -1,15 +1,10 @@
 import type { Blockchain } from "@acala-network/chopsticks-core"
 import { getSyncProvider } from "@polkadot-api/json-rpc-provider-proxy"
 import { blockHeader } from "@polkadot-api/substrate-bindings"
-import { state } from "@react-rxjs/core"
 import { JsonRpcProvider } from "polkadot-api/ws-provider/web"
-import { BehaviorSubject, map } from "rxjs"
+import { BehaviorSubject } from "rxjs"
 
 export const chopsticksInstance$ = new BehaviorSubject<Blockchain | null>(null)
-export const isChopsticks$ = state(
-  chopsticksInstance$.pipe(map((v) => !!v)),
-  false,
-)
 
 export const createChopsticksProvider = (endpoint: string) =>
   withChopsticksEnhancer(

--- a/src/pages/Storage/Storage.tsx
+++ b/src/pages/Storage/Storage.tsx
@@ -1,11 +1,10 @@
-import { isChopsticks$ } from "@/chopsticks/chopsticks"
 import { ButtonGroup } from "@/components/ButtonGroup"
 import { DocsRenderer } from "@/components/DocsRenderer"
 import { Chopsticks } from "@/components/Icons"
 import { LoadingMetadata } from "@/components/Loading"
 import { SearchableSelect } from "@/components/Select"
 import { withSubscribe } from "@/components/withSuspense"
-import { lookup$ } from "@/state/chains/chain.state"
+import { canSetStorage$, lookup$ } from "@/state/chains/chain.state"
 import { state, useStateObservable } from "@react-rxjs/core"
 import { FC, useState } from "react"
 import { map } from "rxjs"
@@ -87,7 +86,7 @@ export const Storage = withSubscribe(
 
 const StorageEntry: FC = () => {
   const selectedEntry = useStateObservable(selectedEntry$)
-  const canSetStorage = useStateObservable(isChopsticks$)
+  const canSetStorage = useStateObservable(canSetStorage$)
   const [mode, setMode] = useState<"query" | "decode" | "set">("query")
 
   if (!selectedEntry) return null


### PR DESCRIPTION
This makes the "set storage" option available when connecting to an external chopsticks instance (or any node that implements `dev_setStorage` ackchyually)