### PR TITLE
feat: improve network selection, connection status pill

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { RuntimeCalls } from "./pages/RuntimeCalls"
 import { Storage } from "./pages/Storage"
 import { Transactions } from "./pages/Transactions"
 import { ViewFns } from "./pages/ViewFns"
+import { ConnectionState } from "./components/ConnectionState"
 
 export default function App() {
   return (
@@ -34,6 +35,7 @@ export default function App() {
       </div>
       <Transactions />
       <VaultTxModal />
+      <ConnectionState />
     </div>
   )
 }

--- a/src/components/ConnectionState.tsx
+++ b/src/components/ConnectionState.tsx
@@ -1,0 +1,62 @@
+import { client$, selectedChain$ } from "@/state/chains/chain.state"
+import {
+  liftSuspense,
+  SUSPENSE,
+  useStateObservable,
+  withDefault,
+} from "@react-rxjs/core"
+import { startWith, switchMap, take, timer } from "rxjs"
+
+const firstBlockTime$ = client$.pipeState(
+  switchMap((client) => client.finalizedBlock$.pipe(take(1))),
+  liftSuspense(),
+  startWith(SUSPENSE),
+  switchMap((v) => (v === SUSPENSE ? timer(0, 1000) : [null])),
+  withDefault(null),
+)
+
+export const ConnectionState = () => {
+  const chain = useStateObservable(selectedChain$)
+  const firstBlockTime = useStateObservable(firstBlockTime$)
+
+  const chainName = getChainName(chain)
+
+  return (
+    <div
+      className={`fixed left-4 bottom-4 z-50 flex items-center gap-2 rounded-md border px-3 py-2 text-sm font-medium shadow-md backdrop-blur transition-opacity duration-[250ms] ${
+        firstBlockTime != null ? "opacity-100" : "opacity-0 pointer-events-none"
+      } ${
+        firstBlockTime == null || firstBlockTime < 10
+          ? "border-border bg-popover text-popover-foreground"
+          : firstBlockTime < 30
+            ? "border-amber-500/40 bg-amber-500/10 text-amber-800"
+            : "border-red-500/40 bg-red-500/10 text-red-800"
+      }`}
+      role="status"
+      aria-live="polite"
+      aria-hidden={!firstBlockTime}
+    >
+      <div className="h-3 w-3 rounded-full border-2 animate-spin border-popover-foreground/30 border-t-popover-foreground/80" />
+      <span>Connecting to {chainName}…</span>
+    </div>
+  )
+}
+
+const getChainName = (selectedChain: {
+  network: { id: string; display: string }
+  endpoint: string
+}) => {
+  if (selectedChain.network.id === "custom") {
+    try {
+      const url = new URL(selectedChain.endpoint)
+      if (["127.0.0.1", "localhost"].includes(url.hostname)) {
+        return "Localhost"
+      }
+
+      return url.hostname
+    } catch {
+      return selectedChain.endpoint
+    }
+  }
+  return selectedChain.network.display
+}

--- a/src/pages/Network/Network.tsx
+++ b/src/pages/Network/Network.tsx
@@ -30,6 +30,7 @@ import {
   selectedChain$,
 } from "@/state/chains/chain.state"
 import { addCustomNetwork, getCustomNetwork } from "@/state/chains/networks"
+import { Input } from "@polkahub/ui-components"
 import { useStateObservable } from "@react-rxjs/core"
 import { Check, ChevronDown } from "lucide-react"
 import { FC, useState } from "react"
@@ -43,6 +44,47 @@ export function NetworkSwitcher({
   const [open, setOpen] = useState(false)
   const selectedChain = useStateObservable(selectedChain$)
 
+  const getChainName = () => {
+    if (selectedChain.network.id === "custom") {
+      try {
+        const url = new URL(selectedChain.endpoint)
+        if (["127.0.0.1", "localhost"].includes(url.hostname)) {
+          return "Localhost"
+        }
+
+        return url.hostname
+      } catch {
+        return selectedChain.endpoint
+      }
+    }
+    return selectedChain.network.display
+  }
+  const getNodeName = () => {
+    if (selectedChain.withChopsticks) {
+      return <Chopsticks className="inline-block align-text-top" />
+    }
+
+    if (selectedChain.network.id === "localhost") {
+      try {
+        const url = new URL(selectedChain.endpoint)
+
+        return url.port
+      } catch {
+        return null
+      }
+    }
+
+    if (selectedChain.endpoint === "light-client") {
+      return "Smoldot"
+    }
+
+    return (
+      Object.entries(selectedChain.network.endpoints).find(
+        ([, e]) => selectedChain.endpoint === e,
+      )?.[0] ?? selectedChain.endpoint
+    )
+  }
+
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -54,7 +96,10 @@ export function NetworkSwitcher({
           )}
         >
           <span className="overflow-hidden text-ellipsis">
-            {selectedChain.network.display}
+            {getChainName()}
+            <span className="text-sm text-muted-foreground ml-1">
+              {getNodeName()}
+            </span>
           </span>
           <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
         </Button>
@@ -100,7 +145,7 @@ const NetworkSwitchDialogContent: FC<{
 
   const handleConfirm = () => {
     const chopsticksEnabled = selectedRpc !== "light-client" && withChopsticks
-    if (selectedNetwork.id === "custom-network") {
+    if (selectedNetwork.id === "custom") {
       addCustomNetwork(selectedRpc)
       onChangeChain({
         network: getCustomNetwork(),
@@ -147,59 +192,72 @@ const NetworkSwitchDialogContent: FC<{
                 <div className="text-foreground/50">No networks found.</div>
               </CommandEmpty>
               <ScrollArea className="h-[260px]">
-                {networkCategories.map((category) => (
-                  <CommandGroup key={category.name} heading={category.name}>
-                    {category.networks.map((network) => (
-                      <CommandItem
-                        key={network.id}
-                        onSelect={() => handleNetworkSelect(network)}
-                        value={
-                          network.display.includes(category.name)
-                            ? network.display
-                            : `${category.name} ${network.display}`
-                        }
-                      >
-                        <Check
-                          className={`mr-2 h-4 w-4 ${
-                            selectedNetwork.id === network.id
-                              ? "opacity-100"
-                              : "opacity-0"
-                          }`}
-                        />
-                        {network.display}
-                      </CommandItem>
-                    ))}
-                    {category.name === "Custom" && isValidUri(enteredText) ? (
-                      <CommandItem
-                        value={enteredText}
-                        onSelect={() => {
-                          handleNetworkSelect({
-                            id: "custom-network",
-                            lightclient: false,
-                            endpoints: { custom: enteredText },
-                            display: enteredText,
-                          })
-                        }}
-                      >
-                        <Check
-                          className={`mr-2 h-4 w-4 ${
-                            selectedNetwork.id === "custom-network"
-                              ? "opacity-100"
-                              : "opacity-0"
-                          }`}
-                        />
-                        {enteredText}
-                      </CommandItem>
-                    ) : null}
-                  </CommandGroup>
-                ))}
+                {networkCategories.map((category) => {
+                  if (category.name === "Custom") {
+                    if (!isValidUri(enteredText)) return null
+                    return (
+                      <CommandGroup key={category.name} heading={category.name}>
+                        <CommandItem
+                          value={enteredText}
+                          onSelect={() => {
+                            handleNetworkSelect({
+                              id: "custom",
+                              lightclient: false,
+                              endpoints: { custom: enteredText },
+                              display: enteredText,
+                            })
+                          }}
+                        >
+                          <Check
+                            className={`mr-2 h-4 w-4 ${
+                              selectedNetwork.id === "custom"
+                                ? "opacity-100"
+                                : "opacity-0"
+                            }`}
+                          />
+                          {enteredText}
+                        </CommandItem>
+                      </CommandGroup>
+                    )
+                  }
+
+                  return (
+                    <CommandGroup key={category.name} heading={category.name}>
+                      {category.networks.map((network) => (
+                        <CommandItem
+                          key={network.id}
+                          onSelect={() => handleNetworkSelect(network)}
+                          value={
+                            network.display.includes(category.name)
+                              ? network.display
+                              : `${category.name} ${network.display}`
+                          }
+                        >
+                          <Check
+                            className={`mr-2 h-4 w-4 ${
+                              selectedNetwork.id === network.id
+                                ? "opacity-100"
+                                : "opacity-0"
+                            }`}
+                          />
+                          {network.display}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  )
+                })}
               </ScrollArea>
             </CommandList>
           </CommandPopover>
           <div className="h-[50vh] flex flex-col gap-2">
             {selectedNetwork ? (
               <div className="grow overflow-hidden flex flex-col">
-                <p className="py-2">Network: {selectedNetwork.display}</p>
+                <p className="py-2">
+                  Network:{" "}
+                  {selectedNetwork.id === "custom"
+                    ? "Custom"
+                    : selectedNetwork.display}
+                </p>
                 <div className="overflow-auto">
                   <RadioGroup
                     value={selectedRpc}
@@ -225,6 +283,13 @@ const NetworkSwitchDialogContent: FC<{
                         />
                       ),
                     )}
+                    {selectedNetwork.id === "localhost" ? (
+                      <CustomPort
+                        selectedRpc={selectedRpc}
+                        setSelectedRpc={setSelectedRpc}
+                        initialPort=""
+                      />
+                    ) : null}
                   </RadioGroup>
                 </div>
               </div>
@@ -259,7 +324,7 @@ const NetworkSwitchDialogContent: FC<{
           disabled={
             !selectedNetwork ||
             !hasChanged ||
-            (selectedNetwork.id === "custom-network" && !selectedRpc)
+            (selectedNetwork.id === "custom" && !selectedRpc)
           }
         >
           Confirm Selection
@@ -319,3 +384,48 @@ const ConnectionOption: FC<{
     ) : null}
   </div>
 )
+
+const CustomPort: FC<{
+  selectedRpc: string
+  setSelectedRpc: (rpc: string) => void
+  initialPort: string
+}> = ({ selectedRpc, setSelectedRpc, initialPort }) => {
+  const [port, setPort] = useState(initialPort)
+  const value = `ws://localhost:${port}`
+  const isSelected = selectedRpc === value
+
+  return (
+    <div
+      className={`overflow-hidden p-3 border rounded-md ${isSelected ? "border-polkadot bg-polkadot/5" : "border-border"}`}
+    >
+      <div className="flex items-start space-x-2">
+        <RadioGroupItem
+          value={value}
+          id="chain-localhost-other"
+          className="mt-1"
+        />
+        <div className="grid gap-0.5 grow">
+          <Label htmlFor="chain-localhost-other" className="font-medium">
+            Other ports
+            <Badge variant="outline" className="ml-2 text-xs">
+              RPC
+            </Badge>
+            <p className="text-xs text-muted-foreground">Local RPC node</p>
+          </Label>
+        </div>
+      </div>
+
+      <div className="mt-2 pt-2 border-t">
+        <Input
+          type="number"
+          placeholder="Port"
+          value={port}
+          onChange={(evt) => {
+            setPort(evt.target.value)
+            setSelectedRpc(`ws://localhost:${evt.target.value}`)
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Network/Network.tsx
+++ b/src/pages/Network/Network.tsx
@@ -194,7 +194,11 @@ const NetworkSwitchDialogContent: FC<{
               <ScrollArea className="h-[260px]">
                 {networkCategories.map((category) => {
                   if (category.name === "Custom") {
-                    if (!isValidUri(enteredText)) return null
+                    if (
+                      !isValidUri(enteredText) ||
+                      enteredText.startsWith("localhost:")
+                    )
+                      return null
                     return (
                       <CommandGroup key={category.name} heading={category.name}>
                         <CommandItem
@@ -243,6 +247,29 @@ const NetworkSwitchDialogContent: FC<{
                           {network.display}
                         </CommandItem>
                       ))}
+                      {category.name === "Localhost" &&
+                      enteredText.startsWith("localhost:") ? (
+                        <CommandItem
+                          value={enteredText}
+                          onSelect={() => {
+                            handleNetworkSelect({
+                              id: "localhost",
+                              lightclient: false,
+                              endpoints: { custom: `ws://${enteredText}` },
+                              display: enteredText,
+                            })
+                          }}
+                        >
+                          <Check
+                            className={`mr-2 h-4 w-4 ${
+                              selectedNetwork.id === "custom"
+                                ? "opacity-100"
+                                : "opacity-0"
+                            }`}
+                          />
+                          {enteredText}
+                        </CommandItem>
+                      ) : null}
                     </CommandGroup>
                   )
                 })}
@@ -287,7 +314,6 @@ const NetworkSwitchDialogContent: FC<{
                       <CustomPort
                         selectedRpc={selectedRpc}
                         setSelectedRpc={setSelectedRpc}
-                        initialPort=""
                       />
                     ) : null}
                   </RadioGroup>
@@ -388,9 +414,12 @@ const ConnectionOption: FC<{
 const CustomPort: FC<{
   selectedRpc: string
   setSelectedRpc: (rpc: string) => void
-  initialPort: string
-}> = ({ selectedRpc, setSelectedRpc, initialPort }) => {
-  const [port, setPort] = useState(initialPort)
+}> = ({ selectedRpc, setSelectedRpc }) => {
+  const [port, setPort] = useState(
+    selectedRpc.startsWith("ws://localhost:")
+      ? selectedRpc.slice("ws://localhost:".length)
+      : "",
+  )
   const value = `ws://localhost:${port}`
   const isSelected = selectedRpc === value
 

--- a/src/state/chains/networks/index.ts
+++ b/src/state/chains/networks/index.ts
@@ -26,7 +26,7 @@ const [Polkadot, Kusama, Paseo, Westend] = (
 ).map((n): Network[] =>
   n.map((x) => ({
     endpoints: x.rpcs as any,
-    lightclient: x.hasChainSpecs,
+    lightclient: !!x.hasChainSpecs,
     id: x.id,
     display: x.display,
     relayChain: x.relayChainInfo?.id,

--- a/src/state/chains/networks/index.ts
+++ b/src/state/chains/networks/index.ts
@@ -38,7 +38,7 @@ const networks = {
   Kusama,
   Paseo,
   Westend,
-  Custom: [
+  Localhost: [
     {
       id: "localhost",
       display: "Localhost",
@@ -48,6 +48,14 @@ const networks = {
         "Port 3000": "ws://127.0.0.1:3000",
         "Port 8132": "ws://127.0.0.1:8132",
       },
+    } as Network,
+  ],
+  Custom: [
+    {
+      id: "custom",
+      display: "Custom",
+      lightclient: false,
+      endpoints: {},
     } as Network,
   ],
 }

--- a/src/state/chains/networks/kusama.json
+++ b/src/state/chains/networks/kusama.json
@@ -3,13 +3,11 @@
     "id": "kusama_asset_hub",
     "display": "Kusama AssetHub",
     "rpcs": {
-      "Dwellir": "wss://asset-hub-kusama-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://statemine-rpc-tn.dwellir.com",
+      "Dwellir": "wss://asset-hub-kusama-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/statemine",
       "IBP2": "wss://asset-hub-kusama.dotters.network",
       "LuckyFriday": "wss://rpc-asset-hub-kusama.luckyfriday.io",
       "Parity": "wss://kusama-asset-hub-rpc.polkadot.io",
-      "RadiumBlock": "wss://statemine.public.curie.radiumblock.co/ws",
       "Stakeworld": "wss://ksm-rpc.stakeworld.io/assethub"
     },
     "relayChainInfo": {
@@ -29,15 +27,14 @@
     "hasChainSpecs": true,
     "rpcs": {
       "Allnodes": "wss://kusama-rpc.publicnode.com",
-      "Dwellir": "wss://kusama-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://kusama-rpc-tn.dwellir.com",
+      "Dwellir": "wss://kusama-rpc.n.dwellir.com",
+      "Helixstreet": "wss://rpc-kusama.helixstreet.io",
       "IBP1": "wss://rpc.ibp.network/kusama",
       "IBP2": "wss://kusama.dotters.network",
       "LuckyFriday": "wss://rpc-kusama.luckyfriday.io",
       "OnFinality": "wss://kusama.api.onfinality.io/public-ws",
-      "RockX": "wss://rockx-ksm.w3node.com/polka-public-ksm/ws",
       "Stakeworld": "wss://ksm-rpc.stakeworld.io",
-      "SubQuery": "wss://kusama.rpc.subquery.network/public/ws"
+      "RockX": "wss://rockx-ksm.w3node.com/polka-public-ksm/ws"
     },
     "nativeToken": {
       "symbol": "KSM",
@@ -48,13 +45,12 @@
     "id": "kusama_bridge_hub",
     "display": "Kusama BridgeHub",
     "rpcs": {
-      "Dwellir": "wss://bridge-hub-kusama-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://kusama-bridge-hub-rpc-tn.dwellir.com",
+      "Dwellir": "wss://bridge-hub-kusama-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/bridgehub-kusama",
       "IBP2": "wss://bridge-hub-kusama.dotters.network",
       "LuckyFriday": "wss://rpc-bridge-hub-kusama.luckyfriday.io",
+      "OnFinality": "wss://bridgehub-kusama.api.onfinality.io/public-ws",
       "Parity": "wss://kusama-bridge-hub-rpc.polkadot.io",
-      "RadiumBlock": "wss://bridgehub-kusama.public.curie.radiumblock.co/ws",
       "Stakeworld": "wss://ksm-rpc.stakeworld.io/bridgehub"
     },
     "relayChainInfo": {
@@ -72,7 +68,7 @@
     "id": "kusama_coretime",
     "display": "Kusama Coretime",
     "rpcs": {
-      "Dwellir": "wss://coretime-kusama-rpc.dwellir.com",
+      "Dwellir": "wss://coretime-kusama-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/coretime-kusama",
       "IBP2": "wss://coretime-kusama.dotters.network",
       "LuckyFriday": "wss://rpc-coretime-kusama.luckyfriday.io",
@@ -94,7 +90,8 @@
     "id": "kusama_people",
     "display": "Kusama People",
     "rpcs": {
-      "Dwellir": "wss://people-kusama-rpc.dwellir.com",
+      "Dwellir": "wss://people-kusama-rpc.n.dwellir.com",
+      "Helixstreet": "wss://rpc-people-kusama.helixstreet.io",
       "IBP1": "wss://sys.ibp.network/people-kusama",
       "IBP2": "wss://people-kusama.dotters.network",
       "LuckyFriday": "wss://rpc-people-kusama.luckyfriday.io",
@@ -116,10 +113,11 @@
     "id": "kusama_encointer",
     "display": "Encointer Network",
     "rpcs": {
-      "Dwellir": "wss://encointer-kusama-rpc.dwellir.com",
+      "Dwellir": "wss://encointer-kusama-rpc.n.dwellir.com",
       "Encointer Association": "wss://kusama.api.encointer.org",
       "IBP1": "wss://sys.ibp.network/encointer-kusama",
-      "IBP2": "wss://encointer-kusama.dotters.network"
+      "IBP2": "wss://encointer-kusama.dotters.network",
+      "LuckyFriday": "wss://rpc-encointer-kusama.luckyfriday.io"
     },
     "relayChainInfo": {
       "id": "kusama",
@@ -141,49 +139,12 @@
       "parachain": 2088
     },
     "rpcs": {
-      "Centrifuge": "wss://fullnode.altair.centrifuge.io",
-      "OnFinality": "wss://altair.api.onfinality.io/public-ws"
+      "OnFinality": "wss://altair.api.onfinality.io/public-ws",
+      "Centrifuge": "wss://fullnode.altair.centrifuge.io"
     },
     "nativeToken": {
       "symbol": "AIR",
       "decimals": 18
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "amplitude",
-    "display": "Amplitude",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2124
-    },
-    "rpcs": {
-      "Dwellir": "wss://amplitude-rpc.dwellir.com",
-      "PendulumChain": "wss://rpc-amplitude.pendulumchain.tech"
-    },
-    "nativeToken": {
-      "symbol": "AMPE",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "bajun",
-    "display": "Bajun Network",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2119
-    },
-    "rpcs": {
-      "AjunaNetwork": "wss://rpc-parachain.bajun.network",
-      "OnFinality": "wss://bajun.api.onfinality.io/public-ws",
-      "RadiumBlock": "wss://bajun.public.curie.radiumblock.co/ws"
-    },
-    "nativeToken": {
-      "symbol": "BAJU",
-      "decimals": 12
     },
     "hasChainSpecs": false
   },
@@ -197,7 +158,7 @@
     },
     "rpcs": {
       "Basilisk": "wss://rpc.basilisk.cloud",
-      "Dwellir": "wss://basilisk-rpc.dwellir.com"
+      "Dwellir": "wss://basilisk-rpc.n.dwellir.com"
     },
     "nativeToken": {
       "symbol": "BSX",
@@ -214,7 +175,6 @@
       "parachain": 2001
     },
     "rpcs": {
-      "Dwellir": "wss://bifrost-rpc.dwellir.com",
       "Liebi": "wss://bifrost-rpc.liebi.com/ws",
       "LiebiUS": "wss://us.bifrost-rpc.liebi.com/ws"
     },
@@ -225,92 +185,27 @@
     "hasChainSpecs": false
   },
   {
-    "id": "calamari",
-    "display": "Calamari",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2084
-    },
+    "id": "shadow",
+    "display": "Crust Shadow",
     "rpcs": {
-      "Manta Network": "wss://calamari.systems"
-    },
-    "nativeToken": {
-      "symbol": "KMA",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
+      "Crust APP": "wss://rpc-shadow.crustnetwork.app",
+      "Crust CC": "wss://rpc-shadow.crustnetwork.cc",
+      "Crust XYZ": "wss://rpc-shadow.crustnetwork.xyz"
+    }
   },
   {
-    "id": "crab",
-    "display": "Crab",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2105
-    },
+    "id": "ipci",
+    "display": "DAO IPCI",
     "rpcs": {
-      "Darwinia": "wss://crab-rpc.darwinia.network/",
-      "Dcdao": "wss://crab-rpc.dcdao.box",
-      "Dwellir": "wss://darwiniacrab-rpc.dwellir.com"
-    },
-    "nativeToken": {
-      "symbol": "CRAB",
-      "decimals": 18
-    },
-    "hasChainSpecs": false
+      "Airalab": "wss://ipci.rpc.robonomics.network"
+    }
   },
   {
-    "id": "imbue",
-    "display": "Imbue Network",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2121
-    },
+    "id": "kabocha",
+    "display": "Kabocha",
     "rpcs": {
-      "Imbue Network 0": "wss://kusama.imbuenetwork.com"
-    },
-    "nativeToken": {
-      "symbol": "IMBU",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "integritee",
-    "display": "Integritee Network",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2015
-    },
-    "rpcs": {
-      "Integritee": "wss://kusama.api.integritee.network",
-      "OnFinality": "wss://integritee-kusama.api.onfinality.io/public-ws"
-    },
-    "nativeToken": {
-      "symbol": "TEER",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "tinker",
-    "display": "InvArch Tinkernet",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2125
-    },
-    "rpcs": {
-      "Dwellir": "wss://tinkernet-rpc.dwellir.com"
-    },
-    "nativeToken": {
-      "symbol": "TNKR",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
+      "JelliedOwl": "wss://kabocha.jelliedowl.net"
+    }
   },
   {
     "id": "karura",
@@ -321,8 +216,7 @@
       "parachain": 2000
     },
     "rpcs": {
-      "Dwellir": "wss://karura-rpc.dwellir.com",
-      "OnFinality": "wss://karura.api.onfinality.io/public-ws"
+      "Dwellir": "wss://karura-rpc.n.dwellir.com"
     },
     "nativeToken": {
       "symbol": "KAR",
@@ -331,25 +225,12 @@
     "hasChainSpecs": false
   },
   {
-    "id": "khala",
-    "display": "Khala Network",
-    "relayChainInfo": {
-      "id": "kusama",
-      "isSystem": false,
-      "parachain": 2004
-    },
+    "id": "kintsugi",
+    "display": "Kintsugi BTC",
     "rpcs": {
-      "Dwellir": "wss://khala-rpc.dwellir.com",
-      "Helikon": "wss://rpc.helikon.io/khala",
-      "OnFinality": "wss://khala.api.onfinality.io/public-ws",
-      "Phala": "wss://khala-api.phala.network/ws",
-      "RadiumBlock": "wss://khala.public.curie.radiumblock.co/ws"
-    },
-    "nativeToken": {
-      "symbol": "PHA",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
+      "Kintsugi Labs": "wss://api-kusama.interlay.io/parachain",
+      "OnFinality": "wss://kintsugi.api.onfinality.io/public-ws"
+    }
   },
   {
     "id": "kreivo",
@@ -370,6 +251,13 @@
     "hasChainSpecs": false
   },
   {
+    "id": "krest",
+    "display": "Krest",
+    "rpcs": {
+      "OnFinality": "wss://krest.api.onfinality.io/public-ws"
+    }
+  },
+  {
     "id": "moonriver",
     "display": "Moonriver",
     "relayChainInfo": {
@@ -379,11 +267,8 @@
     },
     "rpcs": {
       "Moonbeam Foundation": "wss://wss.api.moonriver.moonbeam.network",
-      "Allnodes": "wss://moonriver-rpc.publicnode.com",
-      "Dwellir": "wss://moonriver-rpc.dwellir.com",
-      "OnFinality": "wss://moonriver.api.onfinality.io/public-ws",
-      "RadiumBlock": "wss://moonriver.public.curie.radiumblock.co/ws",
-      "UnitedBloc": "wss://moonriver.unitedbloc.com"
+      "UnitedBloc": "wss://moonriver.unitedbloc.com",
+      "OnFinality": "wss://moonriver.api.onfinality.io/public-ws"
     },
     "nativeToken": {
       "symbol": "MOVR",
@@ -392,22 +277,27 @@
     "hasChainSpecs": false
   },
   {
-    "id": "quartz",
-    "display": "QUARTZ by UNIQUE",
+    "id": "robonomics",
+    "display": "Robonomics",
+    "rpcs": {
+      "Airalab": "wss://kusama.rpc.robonomics.network/"
+    }
+  },
+  {
+    "id": "shiden",
+    "display": "Shiden",
     "relayChainInfo": {
       "id": "kusama",
       "isSystem": false,
-      "parachain": 2095
+      "parachain": 2007
     },
     "rpcs": {
-      "Dwellir": "wss://quartz-rpc.dwellir.com",
-      "Geo Load Balancer": "wss://ws-quartz.unique.network",
-      "Unique America": "wss://us-ws-quartz.unique.network",
-      "Unique Asia": "wss://asia-ws-quartz.unique.network",
-      "Unique Europe": "wss://eu-ws-quartz.unique.network"
+      "Astar": "wss://rpc.shiden.astar.network",
+      "Dwellir": "wss://shiden-rpc.n.dwellir.com",
+      "OnFinality": "wss://shiden.api.onfinality.io/public-ws"
     },
     "nativeToken": {
-      "symbol": "QTZ",
+      "symbol": "SDN",
       "decimals": 18
     },
     "hasChainSpecs": false
@@ -421,15 +311,19 @@
       "parachain": 2007
     },
     "rpcs": {
-      "Astar": "wss://rpc.shiden.astar.network",
-      "Dwellir": "wss://shiden-rpc.dwellir.com",
-      "OnFinality": "wss://shiden.api.onfinality.io/public-ws",
-      "RadiumBlock": "wss://shiden.public.curie.radiumblock.co/ws"
+      "StakeTechnologies": "wss://rpc.shiden.astar.network"
     },
     "nativeToken": {
       "symbol": "SDN",
       "decimals": 18
     },
     "hasChainSpecs": false
+  },
+  {
+    "id": "sora",
+    "display": "SORA",
+    "rpcs": {
+      "Soramitsu": "wss://ws.parachain-collator-2.c2.sora2.soramitsu.co.jp"
+    }
   }
 ]

--- a/src/state/chains/networks/paseo.json
+++ b/src/state/chains/networks/paseo.json
@@ -3,11 +3,11 @@
     "id": "paseo_asset_hub",
     "display": "Paseo AssetHub",
     "rpcs": {
-      "Dwellir": "wss://asset-hub-paseo-rpc.dwellir.com",
+      "Dwellir": "wss://asset-hub-paseo-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/asset-hub-paseo",
       "IBP2": "wss://asset-hub-paseo.dotters.network",
-      "StakeWorld": "wss://pas-rpc.stakeworld.io/assethub",
-      "TurboFlakes": "wss://sys.turboflakes.io/asset-hub-paseo"
+      "TurboFlakes": "wss://sys.turboflakes.io/asset-hub-paseo",
+      "StakeWorld": "wss://pas-rpc.stakeworld.io/assethub"
     },
     "relayChainInfo": {
       "id": "paseo",
@@ -26,7 +26,7 @@
     "hasChainSpecs": true,
     "rpcs": {
       "Amforc": "wss://paseo.rpc.amforc.com",
-      "Dwellir": "wss://paseo-rpc.dwellir.com",
+      "Dwellir": "wss://paseo-rpc.n.dwellir.com",
       "IBP1": "wss://rpc.ibp.network/paseo",
       "IBP2": "wss://paseo.dotters.network",
       "StakeWorld": "wss://pas-rpc.stakeworld.io"
@@ -37,27 +37,10 @@
     }
   },
   {
-    "id": "passet_hub",
-    "display": "PAsset Hub",
-    "rpcs": {
-      "Parity": "wss://testnet-passet-hub.polkadot.io",
-      "IBP1": "wss://passet-hub-paseo.ibp.network"
-    },
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": true,
-      "parachain": 1111
-    },
-    "nativeToken": {
-      "symbol": "PAS",
-      "decimals": 10
-    },
-    "hasChainSpecs": false
-  },
-  {
     "id": "paseo_bridge_hub",
     "display": "Paseo BridgeHub",
     "rpcs": {
+      "IBP1": "wss://bridge-hub-paseo.ibp.network",
       "IBP2": "wss://bridge-hub-paseo.dotters.network"
     },
     "relayChainInfo": {
@@ -72,9 +55,18 @@
     "hasChainSpecs": false
   },
   {
-    "id": "paseo_core_time",
+    "id": "paseo_collectives",
+    "display": "Collectives",
+    "rpcs": {
+      "IBP1": "wss://collectives-paseo.ibp.network",
+      "IBP2": "wss://collectives-paseo.dotters.network"
+    }
+  },
+  {
+    "id": "paseo_coretime",
     "display": "Paseo Coretime",
     "rpcs": {
+      "IBP1": "wss://coretime-paseo.ibp.network",
       "IBP2": "wss://coretime-paseo.dotters.network",
       "ParaNodes": "wss://paseo-coretime.paranodes.io"
     },
@@ -94,6 +86,7 @@
     "display": "Paseo People",
     "rpcs": {
       "Amforc": "wss://people-paseo.rpc.amforc.com",
+      "IBP1": "wss://people-paseo.ibp.network",
       "IBP2": "wss://people-paseo.dotters.network"
     },
     "relayChainInfo": {
@@ -142,6 +135,13 @@
     "hasChainSpecs": false
   },
   {
+    "id": "paseo_aventus",
+    "display": "Aventus",
+    "rpcs": {
+      "Aventus": "wss://avn-parachain.testnet.aventus.io"
+    }
+  },
+  {
     "id": "paseo_bifrost",
     "display": "Bifrost(Paseo)",
     "relayChainInfo": {
@@ -150,7 +150,8 @@
       "parachain": 2030
     },
     "rpcs": {
-      "Liebi": "wss://bifrost-rpc.paseo.liebi.com/ws"
+      "Liebi": "wss://bifrost-rpc.paseo.liebi.com/ws",
+      "Liebi2": "wss://bifrost-rpc.paseo2.liebi.com/ws"
     },
     "nativeToken": {
       "symbol": "BNC",
@@ -159,21 +160,11 @@
     "hasChainSpecs": false
   },
   {
-    "id": "darwinia_koi",
-    "display": "Darwinia Koi",
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": false,
-      "parachain": 2105
-    },
+    "id": "bulletin",
+    "display": "Bulletin (Paseo)",
     "rpcs": {
-      "Darwinia": "wss://koi-rpc.darwinia.network"
-    },
-    "nativeToken": {
-      "symbol": "KRING",
-      "decimals": 18
-    },
-    "hasChainSpecs": false
+      "Parity": "wss://paseo-bulletin-rpc.polkadot.io"
+    }
   },
   {
     "id": "paseo_frequency",
@@ -193,6 +184,20 @@
     "hasChainSpecs": false
   },
   {
+    "id": "heima-paseo",
+    "display": "Heima paseo",
+    "rpcs": {
+      "Heima": "wss://rpc.paseo-parachain.heima.network"
+    }
+  },
+  {
+    "id": "rococoHydraDX",
+    "display": "Hydration (Paseo)",
+    "rpcs": {
+      "Galactic Council": "wss://paseo-rpc.play.hydration.cloud"
+    }
+  },
+  {
     "id": "paseo_hyperbridge",
     "display": "Hyperbridge (Gargantua)",
     "relayChainInfo": {
@@ -206,40 +211,6 @@
     "nativeToken": {
       "symbol": "tBRIDGE",
       "decimals": 12
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "paseo_integritee",
-    "display": "Integritee Network (Paseo)",
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": false,
-      "parachain": 2039
-    },
-    "rpcs": {
-      "Integritee": "wss://paseo.api.integritee.network"
-    },
-    "nativeToken": {
-      "symbol": "TEER",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "paseo_kilt",
-    "display": "KILT Peregrine",
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": false,
-      "parachain": 2086
-    },
-    "rpcs": {
-      "BOTLabs": "wss://peregrine.kilt.io/parachain-public-ws/"
-    },
-    "nativeToken": {
-      "symbol": "PILT",
-      "decimals": 15
     },
     "hasChainSpecs": false
   },
@@ -262,40 +233,6 @@
     "hasChainSpecs": true
   },
   {
-    "id": "paseo_laos_sigma",
-    "display": "Laos Sigma",
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": false,
-      "parachain": 4006
-    },
-    "rpcs": {
-      "freeverse.io": "wss://rpc.laossigma.laosfoundation.io"
-    },
-    "nativeToken": {
-      "symbol": "SIGMA",
-      "decimals": 18
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "paseo_myriad",
-    "display": "Myriad Social Testnet",
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": false,
-      "parachain": 4005
-    },
-    "rpcs": {
-      "myriadPaseo": "wss://ws-rpc.paseo.myriad.social"
-    },
-    "nativeToken": {
-      "symbol": "MYRIA",
-      "decimals": 18
-    },
-    "hasChainSpecs": false
-  },
-  {
     "id": "paseo_niskala",
     "display": "Niskala(Paseo)",
     "relayChainInfo": {
@@ -304,7 +241,6 @@
       "parachain": 4022
     },
     "rpcs": {
-      "Baliola 1": "wss://mlg1.mandalachain.io",
       "Baliola 2": "wss://mlg2.mandalachain.io"
     },
     "nativeToken": {
@@ -314,40 +250,32 @@
     "hasChainSpecs": false
   },
   {
-    "id": "paseo_nodle",
-    "display": "Nodle(Paseo)",
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": false,
-      "parachain": 2026
-    },
+    "id": "muse",
+    "display": "Muse network",
     "rpcs": {
-      "OnFinality": "wss://node-6957502816543653888.lh.onfinality.io/ws?apikey=09b04494-3139-4b57-a5d1-e1c4c18748ce"
-    },
-    "nativeToken": {
-      "symbol": "notNodl",
-      "decimals": 11
-    },
-    "hasChainSpecs": false
+      "Parity": "wss://paseo-muse-rpc.polkadot.io"
+    }
   },
   {
-    "id": "Pop Network",
-    "display": "Pop Network",
-    "relayChainInfo": {
-      "id": "paseo",
-      "isSystem": false,
-      "parachain": 4001
-    },
+    "id": "NeuroWeb",
+    "display": "NeuroWeb Testnet",
     "rpcs": {
-      "R0GUE-RPC1": "wss://rpc1.paseo.popnetwork.xyz",
-      "R0GUE-RPC2": "wss://rpc2.paseo.popnetwork.xyz",
-      "R0GUE-RPC3": "wss://rpc3.paseo.popnetwork.xyz"
-    },
-    "nativeToken": {
-      "symbol": "PAS",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
+      "TraceLabs": "wss://parachain-testnet-rpc.origin-trail.network/"
+    }
+  },
+  {
+    "id": "opal",
+    "display": "OPAL by UNIQUE",
+    "rpcs": {
+      "Geo Load Balancer": "wss://ws-opal.unique.network"
+    }
+  },
+  {
+    "id": "paseoEwx",
+    "display": "PEX",
+    "rpcs": {
+      "Energy Web": "wss://public-rpc.testnet.energywebx.com/"
+    }
   },
   {
     "id": "Xcavate",
@@ -358,7 +286,7 @@
       "parachain": 4003
     },
     "rpcs": {
-      "Xcavate": "wss://rpc-paseo.xcavate.io:443"
+      "Xcavate_OnFinality": "wss://xcavate-paseo.api.onfinality.io/public-ws"
     },
     "nativeToken": {
       "symbol": "XCAV",

--- a/src/state/chains/networks/polkadot.json
+++ b/src/state/chains/networks/polkadot.json
@@ -3,14 +3,11 @@
     "id": "polkadot_asset_hub",
     "display": "AssetHub",
     "rpcs": {
-      "Dwellir": "wss://asset-hub-polkadot-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://statemint-rpc-tn.dwellir.com",
+      "Dwellir": "wss://asset-hub-polkadot-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/asset-hub-polkadot",
       "IBP2": "wss://asset-hub-polkadot.dotters.network",
       "LuckyFriday": "wss://rpc-asset-hub-polkadot.luckyfriday.io",
-      "OnFinality": "wss://statemint.api.onfinality.io/public-ws",
       "Parity": "wss://polkadot-asset-hub-rpc.polkadot.io",
-      "RadiumBlock": "wss://statemint.public.curie.radiumblock.co/ws",
       "Stakeworld": "wss://dot-rpc.stakeworld.io/assethub"
     },
     "relayChainInfo": {
@@ -30,16 +27,15 @@
     "hasChainSpecs": true,
     "rpcs": {
       "Allnodes": "wss://polkadot-rpc.publicnode.com",
-      "Blockops": "wss://polkadot-public-rpc.blockops.network/ws",
-      "Dwellir": "wss://polkadot-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://polkadot-rpc-tn.dwellir.com",
-      "IBP1": "wss://rpc.ibp.network/polkadot",
+      "Dwellir": "wss://polkadot-rpc.n.dwellir.com",
+      "Helixstreet": "wss://rpc-polkadot.helixstreet.io",
+      "IBP1": "wss://polkadot.ibp.network",
       "IBP2": "wss://polkadot.dotters.network",
       "LuckyFriday": "wss://rpc-polkadot.luckyfriday.io",
       "OnFinality": "wss://polkadot.api.onfinality.io/public-ws",
-      "RadiumBlock": "wss://polkadot.public.curie.radiumblock.co/ws",
       "RockX": "wss://rockx-dot.w3node.com/polka-public-dot/ws",
-      "Stakeworld": "wss://dot-rpc.stakeworld.io",
+      "Simply Staking": "wss://spectrum-03.simplystaking.xyz/cG9sa2Fkb3QtMDMtOTFkMmYwZGYtcG9sa2Fkb3Q/LjwBJpV3dIKyWQ/polkadot/mainnet/",
+      "Stakeworld": "wss://rpc-polkadot.stakeworld.io",
       "SubQuery": "wss://polkadot.rpc.subquery.network/public/ws"
     },
     "nativeToken": {
@@ -51,14 +47,12 @@
     "id": "polkadot_bridge_hub",
     "display": "BridgeHub",
     "rpcs": {
-      "Dwellir": "wss://bridge-hub-polkadot-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://polkadot-bridge-hub-rpc-tn.dwellir.com",
+      "Dwellir": "wss://bridge-hub-polkadot-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/bridgehub-polkadot",
       "IBP2": "wss://bridge-hub-polkadot.dotters.network",
       "LuckyFriday": "wss://rpc-bridge-hub-polkadot.luckyfriday.io",
       "OnFinality": "wss://bridgehub-polkadot.api.onfinality.io/public-ws",
       "Parity": "wss://polkadot-bridge-hub-rpc.polkadot.io",
-      "RadiumBlock": "wss://bridgehub-polkadot.public.curie.radiumblock.co/ws",
       "Stakeworld": "wss://dot-rpc.stakeworld.io/bridgehub"
     },
     "relayChainInfo": {
@@ -76,14 +70,12 @@
     "id": "polkadot_collectives",
     "display": "Collectives",
     "rpcs": {
-      "Dwellir": "wss://collectives-polkadot-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://polkadot-collectives-rpc-tn.dwellir.com",
+      "Dwellir": "wss://collectives-polkadot-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/collectives-polkadot",
       "IBP2": "wss://collectives-polkadot.dotters.network",
       "LuckyFriday": "wss://rpc-collectives-polkadot.luckyfriday.io",
       "OnFinality": "wss://collectives.api.onfinality.io/public-ws",
       "Parity": "wss://polkadot-collectives-rpc.polkadot.io",
-      "RadiumBlock": "wss://collectives.public.curie.radiumblock.co/ws",
       "Stakeworld": "wss://dot-rpc.stakeworld.io/collectives"
     },
     "relayChainInfo": {
@@ -101,7 +93,10 @@
     "id": "polkadot_coretime",
     "display": "Coretime",
     "rpcs": {
+      "Dwellir": "wss://coretime-polkadot-rpc.n.dwellir.com",
+      "IBP1": "wss://coretime-polkadot.ibp.network",
       "IBP2": "wss://coretime-polkadot.dotters.network",
+      "LuckyFriday": "wss://rpc-coretime-polkadot.luckyfriday.io",
       "Parity": "wss://polkadot-coretime-rpc.polkadot.io"
     },
     "relayChainInfo": {
@@ -119,11 +114,11 @@
     "id": "polkadot_people",
     "display": "People",
     "rpcs": {
+      "Dwellir": "wss://people-polkadot-rpc.n.dwellir.com",
       "IBP1": "wss://sys.ibp.network/people-polkadot",
       "IBP2": "wss://people-polkadot.dotters.network",
       "LuckyFriday": "wss://rpc-people-polkadot.luckyfriday.io",
-      "Parity": "wss://polkadot-people-rpc.polkadot.io",
-      "RadiumBlock": "wss://people-polkadot.public.curie.radiumblock.co/ws"
+      "Parity": "wss://polkadot-people-rpc.polkadot.io"
     },
     "relayChainInfo": {
       "id": "polkadot",
@@ -145,8 +140,9 @@
       "parachain": 2000
     },
     "rpcs": {
-      "Dwellir": "wss://acala-rpc.dwellir.com",
-      "OnFinality": "wss://acala-polkadot.api.onfinality.io/public-ws"
+      "Dwellir": "wss://acala-rpc.n.dwellir.com",
+      "IBP1": "wss://acala.ibp.network",
+      "IBP2": "wss://acala.dotters.network"
     },
     "nativeToken": {
       "symbol": "ACA",
@@ -165,9 +161,7 @@
     "rpcs": {
       "AjunaNetwork": "wss://rpc-para.ajuna.network",
       "IBP1": "wss://ajuna.ibp.network",
-      "IBP2": "wss://ajuna.dotters.network",
-      "OnFinality": "wss://ajuna.api.onfinality.io/public-ws",
-      "RadiumBlock": "wss://ajuna.public.curie.radiumblock.co/ws"
+      "IBP2": "wss://ajuna.dotters.network"
     },
     "nativeToken": {
       "symbol": "AJUN",
@@ -185,10 +179,7 @@
     },
     "rpcs": {
       "Astar": "wss://rpc.astar.network",
-      "Automata 1RPC": "wss://1rpc.io/astr",
-      "Dwellir": "wss://astar-rpc.dwellir.com",
-      "OnFinality": "wss://astar.api.onfinality.io/public-ws",
-      "RadiumBlock": "wss://astar.public.curie.radiumblock.co/ws"
+      "Dwellir": "wss://astar-rpc.n.dwellir.com"
     },
     "nativeToken": {
       "symbol": "ASTR",
@@ -205,7 +196,7 @@
       "parachain": 2056
     },
     "rpcs": {
-      "Aventus": "wss://public-rpc.mainnet.aventus.network"
+      "Aventus": "wss://avn-parachain.mainnet.aventus.io"
     },
     "nativeToken": {
       "symbol": "AVT",
@@ -222,33 +213,14 @@
       "parachain": 2030
     },
     "rpcs": {
-      "Dwellir": "wss://bifrost-polkadot-rpc.dwellir.com",
       "IBP1": "wss://bifrost-polkadot.ibp.network",
       "IBP2": "wss://bifrost-polkadot.dotters.network",
       "Liebi": "wss://hk.p.bifrost-rpc.liebi.com/ws",
-      "LiebiEU": "wss://eu.bifrost-polkadot-rpc.liebi.com/ws",
-      "RadiumBlock": "wss://bifrost.public.curie.radiumblock.co/ws"
+      "LiebiEU": "wss://eu.bifrost-polkadot-rpc.liebi.com/ws"
     },
     "nativeToken": {
       "symbol": "BNC",
       "decimals": 12
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "bitgreen",
-    "display": "Bitgreen",
-    "relayChainInfo": {
-      "id": "polkadot",
-      "isSystem": false,
-      "parachain": 2048
-    },
-    "rpcs": {
-      "Bitgreen": "wss://mainnet.bitgreen.org"
-    },
-    "nativeToken": {
-      "symbol": "BBB",
-      "decimals": 18
     },
     "hasChainSpecs": false
   },
@@ -261,10 +233,9 @@
       "parachain": 2031
     },
     "rpcs": {
-      "Centrifuge": "wss://fullnode.centrifuge.io",
-      "Dwellir": "wss://centrifuge-rpc.dwellir.com",
       "LuckyFriday": "wss://rpc-centrifuge.luckyfriday.io",
-      "OnFinality": "wss://centrifuge-parachain.api.onfinality.io/public-ws"
+      "OnFinality": "wss://centrifuge-parachain.api.onfinality.io/public-ws",
+      "Centrifuge": "wss://fullnode.centrifuge.io"
     },
     "nativeToken": {
       "symbol": "CFG",
@@ -302,14 +273,20 @@
     },
     "rpcs": {
       "Darwinia": "wss://rpc.darwinia.network",
-      "Dcdao": "wss://darwinia-rpc.dcdao.box",
-      "Dwellir": "wss://darwinia-rpc.dwellir.com"
+      "Subquery": "wss://darwinia.rpc.subquery.network/public/ws"
     },
     "nativeToken": {
       "symbol": "RING",
       "decimals": 18
     },
     "hasChainSpecs": false
+  },
+  {
+    "id": "ewx",
+    "display": "Energy Web X",
+    "rpcs": {
+      "Energy Web": "wss://public-rpc.mainnet.energywebx.com/"
+    }
   },
   {
     "id": "frequency",
@@ -320,16 +297,22 @@
       "parachain": 2091
     },
     "rpcs": {
-      "Dwellir": "wss://frequency-rpc.dwellir.com",
       "Frequency 0": "wss://0.rpc.frequency.xyz",
-      "Frequency 1": "wss://1.rpc.frequency.xyz",
-      "OnFinality": "wss://frequency-polkadot.api.onfinality.io/public-ws"
+      "Frequency 1": "wss://1.rpc.frequency.xyz"
     },
     "nativeToken": {
       "symbol": "FRQCY",
       "decimals": 8
     },
     "hasChainSpecs": false
+  },
+  {
+    "id": "heima",
+    "display": "Heima",
+    "rpcs": {
+      "Dwellir": "wss://heima-rpc.n.dwellir.com",
+      "Heima": "wss://rpc.heima-parachain.heima.network"
+    }
   },
   {
     "id": "hydradx",
@@ -340,10 +323,9 @@
       "parachain": 2034
     },
     "rpcs": {
-      "Dwellir": "wss://hydradx-rpc.dwellir.com",
-      "Galactic Council": "wss://rpc.hydradx.cloud",
+      "Dwellir": "wss://hydration-rpc.n.dwellir.com",
       "Helikon": "wss://rpc.helikon.io/hydradx",
-      "IBP1": "wss://hydradx.paras.ibp.network",
+      "IBP1": "wss://hydration.ibp.network",
       "IBP2": "wss://hydration.dotters.network"
     },
     "nativeToken": {
@@ -372,59 +354,19 @@
     "hasChainSpecs": false
   },
   {
-    "id": "integritee",
-    "display": "Integritee Network",
-    "relayChainInfo": {
-      "id": "polkadot",
-      "isSystem": false,
-      "parachain": 3359
-    },
+    "id": "interlay",
+    "display": "Interlay",
     "rpcs": {
-      "Dwellir": "wss://integritee-rpc.dwellir.com",
-      "Integritee": "wss://polkadot.api.integritee.network"
-    },
-    "nativeToken": {
-      "symbol": "TEER",
-      "decimals": 12
-    },
-    "hasChainSpecs": false
+      "Kintsugi Labs": "wss://api.interlay.io/parachain",
+      "LuckyFriday": "wss://rpc-interlay.luckyfriday.io/"
+    }
   },
   {
-    "id": "invarch",
-    "display": "Invarch Network",
-    "relayChainInfo": {
-      "id": "polkadot",
-      "isSystem": false,
-      "parachain": 3340
-    },
+    "id": "jamton",
+    "display": "JAMTON",
     "rpcs": {
-      "Dwellir": "wss://invarch-rpc.dwellir.com"
-    },
-    "nativeToken": {
-      "symbol": "VARCH",
-      "decimals": 12
-    },
-    "hasChainSpecs": true
-  },
-  {
-    "id": "kilt",
-    "display": "KILT Spiritnet",
-    "relayChainInfo": {
-      "id": "polkadot",
-      "isSystem": false,
-      "parachain": 2086
-    },
-    "rpcs": {
-      "BOTLabs": "wss://spiritnet.kilt.io/",
-      "Dwellir": "wss://kilt-rpc.dwellir.com",
-      "IBP1": "wss://kilt.ibp.network",
-      "IBP2": "wss://kilt.dotters.network"
-    },
-    "nativeToken": {
-      "symbol": "KILT",
-      "decimals": 15
-    },
-    "hasChainSpecs": false
+      "Jamton": "wss://rpc.jamton.network"
+    }
   },
   {
     "id": "laos",
@@ -435,7 +377,7 @@
       "parachain": 3370
     },
     "rpcs": {
-      "Dwellir": "wss://laos-rpc.dwellir.com",
+      "laosfoundation.io": "wss://rpc.laos.laosfoundation.io",
       "freeverse.io": "wss://rpc.laos.laosfoundation.io"
     },
     "nativeToken": {
@@ -453,28 +395,10 @@
       "parachain": 2013
     },
     "rpcs": {
-      "Dwellir": "wss://litentry-rpc.dwellir.com",
       "Litentry": "wss://rpc.litentry-parachain.litentry.io"
     },
     "nativeToken": {
       "symbol": "LIT",
-      "decimals": 18
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "logion",
-    "display": "Logion",
-    "relayChainInfo": {
-      "id": "polkadot",
-      "isSystem": false,
-      "parachain": 3354
-    },
-    "rpcs": {
-      "Logion 1": "wss://para-rpc01.logion.network"
-    },
-    "nativeToken": {
-      "symbol": "LGNT",
       "decimals": 18
     },
     "hasChainSpecs": false
@@ -505,14 +429,10 @@
       "parachain": 2004
     },
     "rpcs": {
-      "Dwellir": "wss://moonbeam-rpc.dwellir.com",
       "IBP1": "wss://moonbeam.ibp.network",
       "IBP2": "wss://moonbeam.dotters.network",
       "Moonbeam Foundation": "wss://wss.api.moonbeam.network",
-      "OnFinality": "wss://moonbeam.api.onfinality.io/public-ws",
-      "RadiumBlock": "wss://moonbeam.public.curie.radiumblock.co/ws",
-      "UnitedBloc": "wss://moonbeam.unitedbloc.com",
-      "Allnodes": "wss://moonbeam-rpc.publicnode.com"
+      "UnitedBloc": "wss://moonbeam.unitedbloc.com"
     },
     "nativeToken": {
       "symbol": "GLMR",
@@ -546,30 +466,11 @@
       "parachain": 2043
     },
     "rpcs": {
-      "Dwellir": "wss://neuroweb-rpc.dwellir.com",
       "TraceLabs": "wss://parachain-rpc.origin-trail.network"
     },
     "nativeToken": {
       "symbol": "NEURO",
       "decimals": 12
-    },
-    "hasChainSpecs": false
-  },
-  {
-    "id": "nodle",
-    "display": "Nodle",
-    "relayChainInfo": {
-      "id": "polkadot",
-      "isSystem": false,
-      "parachain": 2026
-    },
-    "rpcs": {
-      "Dwellir": "wss://nodle-rpc.dwellir.com",
-      "OnFinality": "wss://nodle-parachain.api.onfinality.io/public-ws"
-    },
-    "nativeToken": {
-      "symbol": "NODL",
-      "decimals": 11
     },
     "hasChainSpecs": false
   },
@@ -599,11 +500,7 @@
       "parachain": 2035
     },
     "rpcs": {
-      "Dwellir": "wss://phala-rpc.dwellir.com",
-      "Helikon": "wss://rpc.helikon.io/phala",
-      "OnFinality": "wss://phala.api.onfinality.io/public-ws",
-      "Phala": "wss://api.phala.network/ws",
-      "RadiumBlock": "wss://phala.public.curie.radiumblock.co/ws"
+      "Phala": "wss://api.phala.network/ws"
     },
     "nativeToken": {
       "symbol": "PHA",
@@ -612,25 +509,18 @@
     "hasChainSpecs": false
   },
   {
-    "id": "polimec",
-    "display": "Polimec",
-    "relayChainInfo": {
-      "id": "polkadot",
-      "isSystem": false,
-      "parachain": 3344
-    },
+    "id": "robonomics",
+    "display": "Robonomics",
     "rpcs": {
-      "Amforc": "wss://polimec.rpc.amforc.com",
-      "Helikon": "wss://rpc.helikon.io/polimec",
-      "IBP1": "wss://polimec.ibp.network",
-      "IBP2": "wss://polimec.dotters.network",
-      "Polimec Foundation": "wss://rpc.polimec.org"
-    },
-    "nativeToken": {
-      "symbol": "PLMC",
-      "decimals": 10
-    },
-    "hasChainSpecs": false
+      "Airalab": "wss://polkadot.rpc.robonomics.network/"
+    }
+  },
+  {
+    "id": "sora",
+    "display": "SORA",
+    "rpcs": {
+      "Soramitsu": "wss://ws.parachain-collator-3.pc3.sora2.soramitsu.co.jp"
+    }
   },
   {
     "id": "unique",
@@ -641,7 +531,6 @@
       "parachain": 2037
     },
     "rpcs": {
-      "Dwellir": "wss://unique-rpc.dwellir.com",
       "Geo Load Balancer": "wss://ws.unique.network",
       "IBP1": "wss://unique.ibp.network",
       "IBP2": "wss://unique.dotters.network",
@@ -656,6 +545,13 @@
     "hasChainSpecs": false
   },
   {
+    "id": "xode",
+    "display": "Xode",
+    "rpcs": {
+      "XodeCommunity": "wss://polkadot-rpcnode.xode.net"
+    }
+  },
+  {
     "id": "zeitgeist",
     "display": "Zeitgeist",
     "relayChainInfo": {
@@ -664,8 +560,7 @@
       "parachain": 2092
     },
     "rpcs": {
-      "OnFinality": "wss://zeitgeist.api.onfinality.io/public-ws",
-      "ZeitgeistPM": "wss://main.rpc.zeitgeist.pm/ws"
+      "OnFinality": "wss://zeitgeist.api.onfinality.io/public-ws"
     },
     "nativeToken": {
       "symbol": "ZTG",

--- a/src/state/chains/networks/westend.json
+++ b/src/state/chains/networks/westend.json
@@ -3,11 +3,9 @@
     "id": "westend_asset_hub",
     "display": "Westend AssetHub",
     "rpcs": {
-      "Dwellir": "wss://asset-hub-westend-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://westmint-rpc-tn.dwellir.com",
-      "IBP1": "wss://sys.ibp.network/westmint",
-      "IBP2": "wss://asset-hub-westend.dotters.network",
-      "Parity": "wss://westend-asset-hub-rpc.polkadot.io"
+      "Dwellir": "wss://asset-hub-westend-rpc.n.dwellir.com",
+      "Parity": "wss://westend-asset-hub-rpc.polkadot.io",
+      "IBP1": "wss://sys.ibp.network/westmint"
     },
     "relayChainInfo": {
       "id": "westend",
@@ -25,13 +23,10 @@
     "display": "Westend Relay Chain",
     "hasChainSpecs": true,
     "rpcs": {
-      "Dwellir": "wss://westend-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://westend-rpc-tn.dwellir.com",
-      "IBP1": "wss://rpc.ibp.network/westend",
-      "IBP2": "wss://westend.dotters.network",
+      "Dwellir": "wss://westend-rpc.n.dwellir.com",
       "OnFinality": "wss://westend.api.onfinality.io/public-ws",
       "Parity": "wss://westend-rpc.polkadot.io",
-      "RadiumBlock": "wss://westend.public.curie.radiumblock.co/ws"
+      "IBP1": "wss://rpc.ibp.network/westend"
     },
     "nativeToken": {
       "symbol": "WND",
@@ -42,10 +37,7 @@
     "id": "westend_bridge_hub",
     "display": "Westend BridgeHub",
     "rpcs": {
-      "Dwellir": "wss://bridge-hub-westend-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://westend-bridge-hub-rpc-tn.dwellir.com",
-      "IBP1": "wss://sys.ibp.network/bridgehub-westend",
-      "IBP2": "wss://bridge-hub-westend.dotters.network",
+      "Dwellir": "wss://bridge-hub-westend-rpc.n.dwellir.com",
       "Parity": "wss://westend-bridge-hub-rpc.polkadot.io"
     },
     "relayChainInfo": {
@@ -63,10 +55,7 @@
     "id": "westend_collectives",
     "display": "Westend Collectives",
     "rpcs": {
-      "Dwellir": "wss://collectives-westend-rpc.dwellir.com",
-      "Dwellir Tunisia": "wss://westend-collectives-rpc-tn.dwellir.com",
-      "IBP1": "wss://sys.ibp.network/collectives-westend",
-      "IBP2": "wss://collectives-westend.dotters.network",
+      "Dwellir": "wss://collectives-westend-rpc.n.dwellir.com",
       "Parity": "wss://westend-collectives-rpc.polkadot.io"
     },
     "relayChainInfo": {
@@ -81,12 +70,10 @@
     "hasChainSpecs": true
   },
   {
-    "id": "westend_core_time",
+    "id": "westend_coretime",
     "display": "Westend Coretime",
     "rpcs": {
-      "Dwellir": "wss://coretime-westend-rpc.dwellir.com",
-      "IBP1": "wss://sys.ibp.network/coretime-westend",
-      "IBP2": "wss://coretime-westend.dotters.network",
+      "Dwellir": "wss://coretime-westend-rpc.n.dwellir.com",
       "Parity": "wss://westend-coretime-rpc.polkadot.io"
     },
     "relayChainInfo": {
@@ -101,13 +88,12 @@
     "hasChainSpecs": false
   },
   {
-    "id": "westend_people_chain",
+    "id": "westend_people",
     "display": "Westend People",
     "rpcs": {
-      "Dwellir": "wss://people-westend-rpc.dwellir.com",
-      "IBP1": "wss://sys.ibp.network/people-westend",
-      "IBP2": "wss://people-westend.dotters.network",
-      "Parity": "wss://westend-people-rpc.polkadot.io"
+      "Dwellir": "wss://people-westend-rpc.n.dwellir.com",
+      "Parity": "wss://westend-people-rpc.polkadot.io",
+      "IBP1": "wss://sys.ibp.network/people-westend"
     },
     "relayChainInfo": {
       "id": "westend",
@@ -119,6 +105,13 @@
       "decimals": 12
     },
     "hasChainSpecs": false
+  },
+  {
+    "id": "bulletin",
+    "display": "Bulletin (Westend)",
+    "rpcs": {
+      "Parity": "wss://westend-bulletin-rpc.polkadot.io"
+    }
   },
   {
     "id": "westend_penpal",


### PR DESCRIPTION
Closes #126 

Improvements on the network selection:

It shows the selected node (IBP, Parity, etc. smoldot):
<img width="307" height="89" alt="image" src="https://github.com/user-attachments/assets/d491292a-184a-45d3-a731-9df2113956c8" />

Custom URLs show up with whatever fits of the URL instead of "localhost" (which was missleading)
<img width="309" height="89" alt="image" src="https://github.com/user-attachments/assets/4088e144-8dd6-4889-b684-1567f25a0ba3" />

Localhost shows the port number
<img width="314" height="92" alt="image" src="https://github.com/user-attachments/assets/4390387e-5c6e-4e2f-af02-e2d73c4a1fbf" />

Localhost has an option for other ports:
<img width="405" height="273" alt="image" src="https://github.com/user-attachments/assets/d2532624-b848-4278-ba62-607873525035" />

Also shortcut inputting `localhost:port` now works.


And also adds a spinner when waiting for the first block, at the bottom left:

<img width="277" height="136" alt="image" src="https://github.com/user-attachments/assets/ade50679-19e3-4b3d-9036-577dc53d2928" />

Turns yellow and then red as more time passes without a block
<img width="267" height="88" alt="image" src="https://github.com/user-attachments/assets/892e133f-ef8b-4268-a3b8-81643fe77ad4" />
