### PR TITLE
Add Bulletin Chain endpoint for Polkadot mainnet (paraId 1010)

### DIFF
--- a/src/state/chains/chainspecs/polkadot_bulletin.ts
+++ b/src/state/chains/chainspecs/polkadot_bulletin.ts
@@ -1,0 +1,23 @@
+export const chainSpec = JSON.stringify({
+  name: "Polkadot Bulletin",
+  id: "bulletin-polkadot",
+  chainType: "Live",
+  bootNodes: [
+    "/dns/bulletin.dpstk.de/tcp/30333/p2p/12D3KooWHPmACsPbXDo9n4qjBZqGEqJ7JLG2fvaCWNCMWyysg6vQ",
+    "/dns/bulletin.amperfix.de/tcp/30333/p2p/12D3KooWMc7ZJ6JGiehG1H45JL69QTPivEBnzm8LihkEEFjYMRnr",
+    "/dns/bulletin.dpstk.de/tcp/30335/wss/p2p/12D3KooWHPmACsPbXDo9n4qjBZqGEqJ7JLG2fvaCWNCMWyysg6vQ",
+    "/dns/bulletin.amperfix.de/tcp/30335/wss/p2p/12D3KooWMc7ZJ6JGiehG1H45JL69QTPivEBnzm8LihkEEFjYMRnr",
+  ],
+  properties: {
+    ss58Format: 0,
+    tokenDecimals: 10,
+    tokenSymbol: "DOT",
+  },
+  relay_chain: "polkadot",
+  para_id: 1010,
+  codeSubstitutes: {},
+  genesis: {
+    stateRootHash:
+      "0x97b06f8b8861647a5cc2664d51362b9429302f9d44a0d2c05cc98735a11d6a05",
+  },
+})

--- a/src/state/chains/networks/polkadot.json
+++ b/src/state/chains/networks/polkadot.json
@@ -132,6 +132,23 @@
     "hasChainSpecs": true
   },
   {
+    "id": "polkadot_bulletin",
+    "display": "Bulletin",
+    "rpcs": {
+      "Parity": "wss://polkadot-bulletin-rpc.polkadot.io"
+    },
+    "relayChainInfo": {
+      "id": "polkadot",
+      "isSystem": true,
+      "parachain": 1010
+    },
+    "nativeToken": {
+      "symbol": "DOT",
+      "decimals": 10
+    },
+    "hasChainSpecs": true
+  },
+  {
     "id": "acala",
     "display": "Acala",
     "relayChainInfo": {

--- a/src/state/chains/networks/polkadot.json
+++ b/src/state/chains/networks/polkadot.json
@@ -135,7 +135,8 @@
     "id": "polkadot_bulletin",
     "display": "Bulletin",
     "rpcs": {
-      "Parity": "wss://polkadot-bulletin-rpc.polkadot.io"
+      "Parity": "wss://bulletin-rpc.polkadot.io",
+      "Spectrum": "wss://spectrum-03.simplystaking.xyz/cG9sa2Fkb3QtMDMtOTFkMmYwZGYtcG9sa2Fkb3Q/9QbAeudedsupNA/polkadotbulletin/mainnet/"
     },
     "relayChainInfo": {
       "id": "polkadot",


### PR DESCRIPTION
## Summary
- Add Bulletin Chain as a Polkadot system parachain with paraId 1010
- Configured with Parity and Spectrum RPC endpoints
- Add light chainspec for Smoldot support (genesis stateRootHash sourced from Bulletin chain, boot nodes from [paritytech/chainspecs](https://github.com/paritytech/chainspecs/blob/efe78a594ad7ec52685b6cb1d9eec787f04a1bc5/polkadot/parachain/bulletin/chainspec.json))
- Matches system chain configuration (relayChainInfo, nativeToken DOT, lightclient support)

## Reference
- https://github.com/polkadot-js/apps/pull/12274
- https://github.com/paritytech/polkadot-bulletin-chain/issues/343