### PR TITLE
feat: improve json-display copy button

### DIFF
--- a/src/components/jsonDisplay.css
+++ b/src/components/jsonDisplay.css
@@ -1,9 +1,21 @@
 .json-view .json-view--copy {
-  opacity: 0.4;
+  position: sticky;
+  right: 0;
+  backdrop-filter: brightness(10);
+  border-radius: 4px;
 }
-.json-view .json-view--copy:hover {
+.dark .json-view .json-view--copy {
+  backdrop-filter: brightness(0);
+}
+.json-view .json-view--copy path {
+  opacity: 0.6;
+}
+.json-view .json-view--copy:hover path {
   opacity: 1;
 }
 .json-view .jv-button {
   padding: 0 0.3rem;
+}
+.json-view .json-view--pair {
+  white-space: nowrap;
 }


### PR DESCRIPTION
It's a small thing that annoyed me for a long time, elements within a single line would wrap around to the next one if there wasn't enough space, and so would the "copy" button when hovering, shifting every other property while moving the mouse around.

Now values don't wrap anymore, while the copy button is always visible (no need to scroll all the way to the right to copy a long value)

<img width="444" height="245" alt="image" src="https://github.com/user-attachments/assets/cb29d219-59bc-4476-9f12-03f780c1394a" />
