### PR TITLE
fix: do not crash on fee estimation

### DIFF
--- a/src/pages/Extrinsics/SubmitTx/SubmitExtrinsic.tsx
+++ b/src/pages/Extrinsics/SubmitTx/SubmitExtrinsic.tsx
@@ -47,6 +47,7 @@ import {
   combineLatest,
   defer,
   map,
+  of,
   scan,
   switchMap,
   timer,
@@ -187,6 +188,7 @@ const paymentInfo$ = state(
         switchMap(() =>
           tx.getPaymentInfo(account.signer!.publicKey, txOptions),
         ),
+        catchError(() => of(null)),
       )
     }),
     liftSuspense(),


### PR DESCRIPTION
Repro: https://dev.papi.how/extrinsics#networkId=polkadot_asset_hub&endpoint=wss%3A%2F%2Fsys.ibp.network%2Fasset-hub-polkadot&data=0x1f0d04010100c91f040802020907040300a0b86991c6218b36c1d19d4a2e9eb0ce3606eb48000002020907040300dac17f958d2ee523a2206206994597c13d831ec7000284d717010402020907040300dac17f958d2ee523a2206206994597c13d831ec70104040d0102080001010008506739fd4d780e290bfe42bfe7c0c90691d191883cbfa6113ef6e0c4bb732300

Fee estimation can error, I reproduced it with xcm stuff.