### PR TITLE
fix: rounding integer parts in TokenAmount

### DIFF
--- a/src/components/Extrinsics/Priority.tsx
+++ b/src/components/Extrinsics/Priority.tsx
@@ -1,4 +1,4 @@
-import { TokenAmount } from "@/components/TokenAmount"
+import { roundToSignificantDigits, TokenAmount } from "@/components/TokenAmount"
 import { BlockContext } from "@/state/block.state"
 import { client$ } from "@/state/chains/chain.state"
 import { polkadot_people } from "@polkadot-api/descriptors"
@@ -53,7 +53,7 @@ export const AnalyzePriority: FC<{
               />
               <DetailRow
                 label="Weight"
-                value={`${(Number(details.queryInfo.weight.proof_size) / 1024).toLocaleString(undefined, { maximumSignificantDigits: 3 })} KB / ${(Number(details.queryInfo.weight.ref_time) / 1_000_000).toLocaleString(undefined, { maximumSignificantDigits: 3 })} Mref`}
+                value={`${roundToSignificantDigits(Number(details.queryInfo.weight.proof_size) / 1024)} KB / ${roundToSignificantDigits(Number(details.queryInfo.weight.ref_time) / 1_000_000)} Mref`}
               />
             </div>
           </div>

--- a/src/components/TokenAmount.tsx
+++ b/src/components/TokenAmount.tsx
@@ -10,12 +10,9 @@ export const formatToken = (
     symbol?: string
   },
 ) => {
-  const formattedValue = (
-    Number(amount) /
-    10 ** properties.decimals
-  ).toLocaleString(undefined, {
-    maximumSignificantDigits: 3,
-  })
+  const formattedValue = roundToSignificantDigits(
+    Number(amount) / 10 ** properties.decimals,
+  )
 
   return `${formattedValue} ${properties.symbol}`
 }
@@ -40,4 +37,17 @@ export const TokenAmount: FC<{
       })}
     </span>
   )
+}
+
+export const roundToSignificantDigits = (value: number) => {
+  const abs = Math.abs(value)
+  const maximumFractionDigits = abs >= 100 ? 0 : abs >= 10 ? 1 : 2
+
+  return abs >= 1
+    ? value.toLocaleString(undefined, {
+        maximumFractionDigits,
+      })
+    : value.toLocaleString(undefined, {
+        maximumSignificantDigits: 3,
+      })
 }


### PR DESCRIPTION
Previously, `54321.46372 DOT` would get formatted as `'54,300 DOT'`, the idea was to show at most 3 significant digits on the fraction side, but this meant that integer parts would also get rounded to 0, which was misleading.

Now it correctly formats:
- `54321.46372 => 54,321 DOT`
- `54.32146372 => 54.3 DOT`
- `0.5432146372 => 0.543 DOT`
- `0.05432146372 => 0.0543 DOT`