### PR TITLE
Add Rotko RPCs to Polkadot, Kusama and Paseo system chains

### DIFF
--- a/src/state/chains/networks/kusama.json
+++ b/src/state/chains/networks/kusama.json
@@ -5,7 +5,8 @@
     "rpcs": {
       "Dwellir": "wss://asset-hub-kusama-rpc.n.dwellir.com",
       "LuckyFriday": "wss://rpc-asset-hub-kusama.luckyfriday.io",
-      "Parity": "wss://kusama-asset-hub-rpc.polkadot.io"
+      "Parity": "wss://kusama-asset-hub-rpc.polkadot.io",
+      "Rotko": "wss://asset-hub-kusama.rotko.net"
     },
     "relayChainInfo": {
       "id": "kusama",
@@ -43,7 +44,8 @@
       "Dwellir": "wss://bridge-hub-kusama-rpc.n.dwellir.com",
       "LuckyFriday": "wss://rpc-bridge-hub-kusama.luckyfriday.io",
       "OnFinality": "wss://bridgehub-kusama.api.onfinality.io/public-ws",
-      "Parity": "wss://kusama-bridge-hub-rpc.polkadot.io"
+      "Parity": "wss://kusama-bridge-hub-rpc.polkadot.io",
+      "Rotko": "wss://bridge-hub-kusama.rotko.net"
     },
     "relayChainInfo": {
       "id": "kusama",
@@ -62,7 +64,8 @@
     "rpcs": {
       "Dwellir": "wss://coretime-kusama-rpc.n.dwellir.com",
       "LuckyFriday": "wss://rpc-coretime-kusama.luckyfriday.io",
-      "Parity": "wss://kusama-coretime-rpc.polkadot.io"
+      "Parity": "wss://kusama-coretime-rpc.polkadot.io",
+      "Rotko": "wss://coretime-kusama.rotko.net"
     },
     "relayChainInfo": {
       "id": "kusama",
@@ -82,7 +85,8 @@
       "Dwellir": "wss://people-kusama-rpc.n.dwellir.com",
       "Helixstreet": "wss://rpc-people-kusama.helixstreet.io",
       "LuckyFriday": "wss://rpc-people-kusama.luckyfriday.io",
-      "Parity": "wss://kusama-people-rpc.polkadot.io"
+      "Parity": "wss://kusama-people-rpc.polkadot.io",
+      "Rotko": "wss://people-kusama.rotko.net"
     },
     "relayChainInfo": {
       "id": "kusama",
@@ -101,7 +105,8 @@
     "rpcs": {
       "Dwellir": "wss://encointer-kusama-rpc.n.dwellir.com",
       "Encointer Association": "wss://kusama.api.encointer.org",
-      "LuckyFriday": "wss://rpc-encointer-kusama.luckyfriday.io"
+      "LuckyFriday": "wss://rpc-encointer-kusama.luckyfriday.io",
+      "Rotko": "wss://encointer-kusama.rotko.net"
     },
     "relayChainInfo": {
       "id": "kusama",

--- a/src/state/chains/networks/paseo.json
+++ b/src/state/chains/networks/paseo.json
@@ -35,7 +35,8 @@
     "id": "paseo_people_chain",
     "display": "Paseo People",
     "rpcs": {
-      "Amforc": "wss://people-paseo.rpc.amforc.com"
+      "Amforc": "wss://people-paseo.rpc.amforc.com",
+      "Rotko": "wss://people-paseo.rotko.net"
     },
     "relayChainInfo": {
       "id": "paseo",

--- a/src/state/chains/networks/polkadot.json
+++ b/src/state/chains/networks/polkadot.json
@@ -48,7 +48,8 @@
       "LuckyFriday": "wss://rpc-bridge-hub-polkadot.luckyfriday.io",
       "OnFinality": "wss://bridgehub-polkadot.api.onfinality.io/public-ws",
       "Parity": "wss://polkadot-bridge-hub-rpc.polkadot.io",
-      "Stakeworld": "wss://rpc-bridge-hub-polkadot.stakeworld.io"
+      "Stakeworld": "wss://rpc-bridge-hub-polkadot.stakeworld.io",
+      "Rotko": "wss://bridge-hub-polkadot.rotko.net"
     },
     "relayChainInfo": {
       "id": "polkadot",
@@ -68,7 +69,8 @@
       "Dwellir": "wss://collectives-polkadot-rpc.n.dwellir.com",
       "LuckyFriday": "wss://rpc-collectives-polkadot.luckyfriday.io",
       "OnFinality": "wss://collectives.api.onfinality.io/public-ws",
-      "Parity": "wss://polkadot-collectives-rpc.polkadot.io"
+      "Parity": "wss://polkadot-collectives-rpc.polkadot.io",
+      "Rotko": "wss://collectives-polkadot.rotko.net"
     },
     "relayChainInfo": {
       "id": "polkadot",
@@ -87,7 +89,8 @@
     "rpcs": {
       "Dwellir": "wss://coretime-polkadot-rpc.n.dwellir.com",
       "LuckyFriday": "wss://rpc-coretime-polkadot.luckyfriday.io",
-      "Parity": "wss://polkadot-coretime-rpc.polkadot.io"
+      "Parity": "wss://polkadot-coretime-rpc.polkadot.io",
+      "Rotko": "wss://coretime-polkadot.rotko.net"
     },
     "relayChainInfo": {
       "id": "polkadot",
@@ -107,7 +110,8 @@
       "Dwellir": "wss://people-polkadot-rpc.n.dwellir.com",
       "LuckyFriday": "wss://rpc-people-polkadot.luckyfriday.io",
       "Parity": "wss://polkadot-people-rpc.polkadot.io",
-      "Stakeworld": "wss://rpc-people-polkadot.stakeworld.io"
+      "Stakeworld": "wss://rpc-people-polkadot.stakeworld.io",
+      "Rotko": "wss://people-polkadot.rotko.net"
     },
     "relayChainInfo": {
       "id": "polkadot",


### PR DESCRIPTION
Adds Rotko public RPC endpoints to the Polkadot, Kusama and Paseo system chains. All endpoints are live and were verified with a `system_chain` call before submitting.

Polkadot: bridge hub, collectives, coretime, people
Kusama: asset hub, bridge hub, coretime, people, encointer
Paseo: people

- wss://bridge-hub-polkadot.rotko.net
- wss://collectives-polkadot.rotko.net
- wss://coretime-polkadot.rotko.net
- wss://people-polkadot.rotko.net
- wss://asset-hub-kusama.rotko.net
- wss://bridge-hub-kusama.rotko.net
- wss://coretime-kusama.rotko.net
- wss://people-kusama.rotko.net
- wss://encointer-kusama.rotko.net
- wss://people-paseo.rotko.net